### PR TITLE
docs: rework every page into a neutral, precise register

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -71,6 +71,17 @@ Companion documents in this folder (kept separate only because they are larger i
   say what you forgot"). Every sentence must carry information a reader did not have; if a sentence
   only sets up the next one, delete it. This is a hard rule across the whole site, and reviewers check
   it.
+- **The register is neutral and precise: plain declarative sentences (user directive).** The README's
+  "Why ry" and "Type system" sections are the style reference. No punchy fragments or sales lines
+  ("no options to argue about", "built for exactly this job", "One more thing"), no rhetorical
+  build-up ("Read that error carefully, because it is the whole idea"), and no promoting an
+  incidental fact into a selling point. State a limit as a fact rather than as candour about a limit
+  — "the honest way to find out" is just "how you find out". **Motivate a design decision with the
+  technical reason**, not with its virtue: R is highly dynamic, ry targets soundness and speed on
+  large codebases, so inference is Hindley–Milner, and class hierarchies plus user-side overloading
+  are excluded because a system admitting them can spend unbounded time on one expression. Where a
+  construct cannot be described statically it is `Unknown`, so a gap is a skipped check rather than a
+  wrong answer.
 - **Never rely on a capability the page has not introduced yet.** The Features page builds
   navigation → syntax errors → formatting → rename → the type checker, so an example that needs
   inference cannot appear before the reveal. An example is evidence for the section it sits in.
@@ -93,6 +104,14 @@ Companion documents in this folder (kept separate only because they are larger i
 - **Docs claims are verified against the binary, never against other docs.** A prior pass shipped a
   fabricated JSON example and formatter behaviour the tool does not have; the rewrite caught a
   fabricated `--output json` sample still in the install page. Run examples before writing them down.
+  A pass that only intended to change *prose* still found five false claims, so re-run the examples
+  even when the edit is stylistic. The kinds that drift: **quoted diagnostic text** truncated or
+  paraphrased (the `@type`/`@alias` block message, the misplaced-config-key warning), **rendered
+  types missing their binder** (a hover written `fn(x: T) -> …` when the tool prints
+  `<T> fn(x: T) -> …`), **flag behaviour described from intent** (`--min-severity error` was said to
+  still print warnings; it suppresses them entirely), and **a capability claimed in several pages at
+  once** (strict mode "makes every tolerated read visible" — it does not; see `backlog.md`). Driving
+  the LSP server over stdio from a throwaway script is the way to check hover and completion.
 
 ### Architecture
 

--- a/.agents/memory/backlog.md
+++ b/.agents/memory/backlog.md
@@ -839,6 +839,30 @@ unknown key a hard error when the file is a *local* `ry.toml` while keeping the 
 compatibility only where it is actually needed. Decide it deliberately; the current forward-compat
 rationale (`config.rs`, `Config::unknown_keys`) is written down and is not obviously wrong.
 
+## Open — strict mode does not surface reads tolerated by an unknown attached package
+
+The blanket tolerance is the one hole strict mode leaves open, and three docs pages had claimed the
+opposite ("`strict = true` makes every tolerated read visible"). Measured: with a
+`library(<package with no manifest>)` in the project, a read of a name nothing defines produces **no
+finding at all** under `[check] typing = true, strict = true` — verified across four shapes (bare
+read, call, call assigned then used, and the value used numerically; all report `no problems`).
+
+The cause is a boundary rather than a bug: the tolerance is applied while names are resolved, and
+strict mode reports undetermined *types* at their origin. `type-system.md` explicitly excludes an
+unresolved-name reference from being a strict origin, because naming already reports it — but a
+*tolerated* read is precisely the case where naming does not, so it falls between the two layers.
+
+This matters because it is the failure mode this project treats as worst: a clean strict run that
+reads as "I understood everything" while an unknown `library()` silently switched a whole class of
+checking off project-wide. The fix is presumably to record tolerated reads as strict origins (they
+are genuinely undetermined), which needs naming to hand the origin to the strict stream. Until then
+the docs say so plainly — `limitations.md` and `stubs.md` now state that strict does not close it,
+and that declaring the package is what does.
+
+Adjacent and still true: strict *does* report `Unknown` origins from unsupported constructs and from
+`Any`-returning stub calls (`min()` on a classed value, `data.frame()`, `subset()`, `df$amount` all
+verified), and it *does* escalate genuinely-unresolved names from warning to error.
+
 ## Open — `htmltools` and `mgcv` spin on CPU at flat memory
 
 Checking `htmltools`'s package directory (7,669 lines) runs past **five minutes** at 100% CPU and

--- a/crates/format/tests/formatter.template.md
+++ b/crates/format/tests/formatter.template.md
@@ -4,7 +4,7 @@ description: Every rule the formatter applies, with a before-and-after for each
 ---
 <!-- R CODE IN THIS FILE IS FORMATTED AND SAVED TO docs/src/content/docs/reference/formatting-rules.md -->
 
-ry includes a non-invasive R code formatter that emphasizes readability while respecting the existing structure of your code.
+ry includes a non-invasive R code formatter. It normalizes spacing, indentation and bracing, and preserves the structure you wrote.
 
 ## Usage
 
@@ -17,22 +17,22 @@ ry fmt --check   # List files that would be reformatted, without writing
 ry fmt --diff    # Show a diff of formatting changes without applying them
 ```
 
-`--check` and `--diff` exit 1 when any file would change, so they slot straight into CI. Errors
+`--check` and `--diff` exit 1 when any file would change, which is what a CI job gates on. Errors
 (for example a file that cannot be parsed) exit 2 — see the full
 [exit-code table](/reference/cli#exit-codes).
 
 ## Philosophy
 
-ry's non-invasive approach means it respects your existing line breaks and won’t arbitrarily split expressions you’ve chosen to keep on one line. The formatter is guided by these principles:
+The formatter preserves existing line breaks and does not split expressions that are written on one line. Four principles follow from that:
 
-* **Single-line expressions remain single-line:** The formatter only adds line breaks if the expression is already multi-line, and will never break single-line expressions into multiple lines (with [one exception](#loops)).
-* **Flexible style preservation:** Both compact ("hugged") and expanded forms for nested expressions are supported, so your preferred style is respected (see [hugging behavior](#hugging-behavior)).
-* **Automatic braces only when needed:** Braces are added automatically only where they prevent subtle bugs (see [auto-bracing](#auto-bracing)).
-* **Minimal configuration:** The formatter works out of the box with sensible defaults, so you can use it immediately without extra setup (see [configuration](/reference/configuration)).
+* **Single-line expressions remain single-line:** The formatter adds line breaks only where the expression is already multi-line, and never breaks a single-line expression into several (with [one exception](#loops)).
+* **Both nesting styles are preserved:** Compact ("hugged") and expanded forms for nested expressions are equally valid, and neither is rewritten into the other (see [hugging behavior](#hugging-behavior)).
+* **Braces are added only where they prevent a bug:** Auto-bracing applies where omitting braces changes what a later edit means (see [auto-bracing](#auto-bracing)).
+* **Two configuration keys:** Indent width and line endings, both documented under [configuration](/reference/configuration). There are no style options, because a reflowing formatter would rewrite line breaks the author chose.
 
 ## Formatting Rules
 
-Below is a comprehensive list of rules describing the behavior of the formatter for different kinds of expressions, including edge cases where special handling is applied.
+The rules below describe the formatter's behavior for each kind of expression, including the edge cases that receive special handling.
 
 ### Binary Operators
 
@@ -177,7 +177,7 @@ if (
 
 Loops are the only expressions that are **not allowed** on a single line.
 
-Because `for`, `while`, and `repeat` loops are used solely for their side effects and do not return meaningful values, the formatter always requires these loops to be written across multiple lines with explicit braces (see [auto-bracing](#auto-bracing)). This ensures that side-effecting code is visually distinct from pure expressions.
+`for`, `while`, and `repeat` loops are evaluated for their side effects and return no meaningful value, so the formatter writes them across multiple lines with explicit braces (see [auto-bracing](#auto-bracing)). This keeps side-effecting code visually distinct from expressions that produce a value.
 
 **For loops** always enforce braced blocks for the body, ensuring consistency:
 
@@ -200,7 +200,7 @@ while(condition) action()
 repeat action()
 ```
 
-**Multiline for loop headers:** The formatter allows both of the following styles for multiline `for` loop headers, preserving your preferred structure:
+**Multiline for loop headers:** Both of the following styles for multiline `for` loop headers are preserved:
 
 ```r
 # for_loops_multline_head: format
@@ -232,7 +232,7 @@ call(
 )
 ```
 
-**Nested function calls** can use either a hugged style—where the inner call starts right after the outer call's parenthesis—or an expanded style. Both are preserved by the formatter, letting you choose the most readable form for your code.
+**Nested function calls** can use either a hugged style — where the inner call starts directly after the outer call's parenthesis — or an expanded style. The formatter preserves both.
 
 ```r
 # hugging_nested_function_calls : format
@@ -259,7 +259,7 @@ call(a = x, b = y, c = inner(
 ))
 ```
 
-This behavior is particularly useful for testing frameworks and S4 method definitions:
+This applies to testing frameworks and S4 method definitions:
 
 ```r
 # test_that_and_s4_example: format
@@ -318,7 +318,7 @@ lapply(data, \(x) {
 
 ### Switch Statements
 
-Switch statements are formatted like normal function calls. For fallthrough cases (e.g., `case = ,`), an extra space is added after the `=` to clearly indicate the fallthrough.
+Switch statements are formatted like ordinary function calls. For fallthrough cases (`case = ,`), an extra space is added after the `=` to mark the fallthrough.
 
 ```r
 # switch_statements : format
@@ -353,7 +353,7 @@ pkg :: process
 pkg ::: filter
 ```
 
-When chaining extract or namespace operators across multiple lines, the formatter indents each subsequent line to make the chain visually distinct and easy to follow:
+When an extract or namespace chain spans several lines, each subsequent line is indented one step:
 
 ```r
 # extract_operator_chained : compare
@@ -364,7 +364,7 @@ call(x, y)
 
 ### String Literals
 
-String literals receive intelligent quote normalization. The formatter prefers double quotes (`"`) unless the string contains unescaped double quotes:
+String literals are normalized to double quotes (`"`), unless the string contains unescaped double quotes:
 
 ```r
 # string_literals : compare
@@ -552,11 +552,11 @@ You can also skip formatting for an entire file by placing `# fmt: skip-file` at
 
 ## Rationale
 
-This section explains the key design decisions that guided the formatter's implementation.
+This section records the design decisions behind the rules above.
 
 ### Auto-Bracing
 
-**Accidental bugs:** It's easy to accidentally introduce subtle bugs when omitting braces in loops, function definitions, or `if` expressions. For example, if you later add a line after an unbraced `if`, only the first line is controlled by the condition:
+**Accidental bugs:** Omitting braces in loops, function definitions, or `if` expressions makes a later edit change what the code means. Adding a line after an unbraced `if` leaves only the first line under the condition:
 
 ```r
 # _ : skip
@@ -589,7 +589,7 @@ for (item in sequence)
 
 ### Hugging Behavior
 
-"Hugging" refers to how nested expressions are formatted in multiline contexts—keeping them compact by allowing inner expressions to start on the same line as the outer expression's opening delimiter. This is part of ry's non-invasive approach: both hugged and expanded formats are allowed.
+"Hugging" is the compact layout for a nested expression in a multiline context: the inner expression starts on the same line as the outer expression's opening delimiter. Both hugged and expanded forms are allowed, and the formatter preserves whichever was written.
 
 **Nested function calls** can be formatted in a hugged style:
 
@@ -622,4 +622,4 @@ result <- outer(
 )
 ```
 
-See the [compact multiline calls](#function-calls) section under Function Calls for more details. The formatter preserves this style, which is especially useful for S4 methods and testing frameworks.
+See [compact multiline calls](#function-calls) under Function Calls. This style is preserved, which is what keeps S4 methods and testing-framework calls intact.

--- a/docs/src/content/docs/contributing/authoring-stubs.md
+++ b/docs/src/content/docs/contributing/authoring-stubs.md
@@ -210,7 +210,7 @@ use of one into a false `unresolved`).
 A manifest does not need a `.Rtypes` file beside it. **Manifest-only namespaces** — `tibble`,
 `tidyr`, `readr`, `purrr`, `stringr`, `forcats`, `lubridate`, `magrittr`, `rlang`, `glue`, `scales`,
 `knitr`, `jsonlite`, `R6`, `tidyverse` — carry no typed declarations at all, so every name from them
-is `Unknown`. What they buy is a **knowable export set**, and that is worth more than it sounds:
+is `Unknown`. What they supply is a **knowable export set**, which matters because
 attaching a package whose exports the checker cannot enumerate turns off unresolved-name detection for
 the whole project (see [the tolerance](/reference/type-system#naming-and-scoping)), so before these manifests
 existed a single `library(stringr)` meant a clean run said nothing about typos anywhere. Adding

--- a/docs/src/content/docs/contributing/design/index.md
+++ b/docs/src/content/docs/contributing/design/index.md
@@ -8,8 +8,8 @@ describes what ry does today and is kept accurate; the pages below describe what
 it might do, what is still undecided, and why. They are deliberately absent from
 the sidebar — this page is the way in.
 
-Read them for the reasoning, not for the current behaviour. Where a draft and the
-rest of the documentation disagree, the rest of the documentation is right. The
+Read them for the reasoning, not for current behaviour. Where a draft and the
+rest of the documentation disagree, the rest of the documentation is correct. The
 authoritative typing contract is the [type system reference](/reference/type-system/),
 and what the checker cannot do yet is listed under
 [limitations](/type-checking/limitations/).
@@ -24,9 +24,8 @@ here as the record of why.
 
 Type-system questions with no settled answer yet, each with the options on the
 table and the current stopgap. Tagged unions, S3 dispatch, data frame and matrix
-modelling, the variadic `...` body, and the import model. Traits are here too, as
-a closed entry — declined rather than deferred, with the reasoning, because
-"why not typeclasses" is a question that keeps coming back.
+modelling, the variadic `...` body, and the import model. Traits are here too as
+a closed entry: declined rather than deferred, with the reasoning recorded.
 
 ### [Data masking](/contributing/design/data-masking/)
 

--- a/docs/src/content/docs/contributing/design/inline-type-syntax.md
+++ b/docs/src/content/docs/contributing/design/inline-type-syntax.md
@@ -155,7 +155,7 @@ to *this* design rather than to the naming decision:
   extensions — but a sibling directory keeps tarball hygiene and roxygen simple and
   leaves no doubt about which file ships.
 
-## 6. The parser work, honestly
+## 6. The parser work
 
 An earlier draft claimed "this is not a large parser change". That was wrong, and
 the reason is specific: **the type grammar is not self-delimiting.** It currently

--- a/docs/src/content/docs/contributing/design/repl.md
+++ b/docs/src/content/docs/contributing/design/repl.md
@@ -226,11 +226,11 @@ architecture; none block the analysis rung:
   prompt clock and sqlite-history timestamps use it); see the Apple-framework
   decision record for why that matters at release time.
 - **History**: sqlite backend (an editor feature flag) and import from
-  `.Rhistory`/radian history formats — cheap onboarding win.
+  `.Rhistory`/radian history formats — low cost, removes a migration step.
 - **E2e assertions**: parse pty output through a vt100 screen model instead
   of grepping raw transcripts — robust against redraws and cursor movement.
-- **Help**: a fuzzy help browser over installed packages is table stakes in
-  the field; ours should come from the analysis stack (hover docs already
+- **Help**: a fuzzy help browser over installed packages, which comparable
+  consoles provide; ours should come from the analysis stack (hover docs already
   exist) rather than a parallel Rd pipeline.
 - **Reprex mode**, rendered through our own formatter.
 - Auto-matching brackets / smart quotes; TOML-config for colors and prompts

--- a/docs/src/content/docs/contributing/testing.md
+++ b/docs/src/content/docs/contributing/testing.md
@@ -3,7 +3,7 @@ title: Testing
 description: The fixture-testing contract and suite structure
 ---
 
-This project prefers fixture tests for source-driven behavior because they are:
+This project prefers fixture tests for source-driven behavior. They are:
 
 - easy for a human to read in diffs
 - easy to extend into many cases quickly
@@ -232,7 +232,7 @@ Behavior:
 - blessing an already-correct suite changes no bytes
 
 Review every blessed change before committing: bless captures whatever the runner currently
-produces, so it will happily record an intentionally wrong outcome if the implementation is wrong.
+produces, so it records an intentionally wrong outcome when the implementation is wrong.
 Fixtures are the desired-semantics contract, not a regression archive — accept a changed
 expectation only when the behavior or wording intentionally improved.
 

--- a/docs/src/content/docs/features.md
+++ b/docs/src/content/docs/features.md
@@ -71,8 +71,9 @@ error[syntax-error]: unclosed `(` in the `if` condition; expected a matching `)`
        ^
 ```
 
-R's parser stops at the first error, because its job is to run your code. A parser written for tooling
-carries on, keeps the rest of the file analyzable, and can say which construct was left open.
+R's parser stops at the first error, because its job is to run your code. A parser written for
+tooling carries on, keeps the rest of the file analyzable, and can say which construct was left
+open.
 
 ## Formatting
 
@@ -88,8 +89,8 @@ x <- c(1, 2, 3)
 if (x > 1) { y <- 2 }
 ```
 
-What it does not do is decide where your line breaks go. Both of these are already formatted, and both
-stay exactly as written:
+It does not decide where your line breaks go. Both of these are already formatted, and both stay
+exactly as written:
 
 ```r
 totals <- summarise(data, by = region)
@@ -100,10 +101,10 @@ breakdown <- summarise(
 )
 ```
 
-You chose one call on a line and the other spread over four; the formatter keeps both. A formatter that
-reflows to a column limit would rewrite one of them, and your next diff would show line breaks instead
-of the change you made. The style itself is fixed, with almost no configuration — the reasoning is in
-[formatting rules](/reference/formatting-rules#philosophy).
+You chose one call on a line and the other spread over four; the formatter keeps both. A formatter
+that reflows to a column limit would rewrite one of them, and the next diff would show line breaks
+instead of the change you made. The style is fixed apart from indent width and line endings; the
+reasoning is in [formatting rules](/reference/formatting-rules#philosophy).
 
 ## Rename
 
@@ -111,40 +112,40 @@ Rename does not search and replace. It runs the same analysis that answers go-to
 occurrence is resolved to the binding it refers to, and only the occurrences bound to the one you
 picked are edited.
 
-That matters because the same word is not the same thing twice. A local `total` inside one function and
-a global `total` used by another are different bindings. A parameter shadows the global of the same
-name for the length of the function. The word appearing inside a string is not a binding at all.
-Renaming one of them must leave the others alone, across every file in the project.
+This matters because the same word is not the same thing twice. A local `total` inside one function
+and a global `total` used by another are different bindings. A parameter shadows the global of the
+same name for the length of the function. The word appearing inside a string is not a binding at
+all. Renaming one of them must leave the others alone, across every file in the project.
 
-## One more thing
+## The type checker
 
 Everything above comes from one model of your project: which names exist, which binding each
-occurrence refers to, and where each is visible. That model is what separates these features from text
-search, and building it is most of the work.
+occurrence refers to, and where each is visible. That model is what separates these features from
+text search, and building it is most of the work.
 
-The type checker goes one step further. It does not only know which binding a name refers to — it
-knows what kind of value that binding holds. Completion does not only know which names exist, it knows
-what is inside them:
+The type checker goes one step further. It knows not only which binding a name refers to, but what
+kind of value that binding holds. Completion therefore knows what is inside a value, not just which
+names exist:
 
 ```r
 account <- list(holder = "ada", balance = 120.5)
 account$        # balance, holder — with their types
 ```
 
-Nothing declared those fields. And hovering a function you never annotated gives you its full type:
+Nothing declared those fields. Hovering a function you never annotated gives you its full type:
 
 ```r
 make <- function(x) list(x, 1L)
 ```
 
 ```text
-make: fn(x: T) -> list{T, integer}
+make: <T> fn(x: T) -> list{T, integer}
 ```
 
-It takes any value and returns a two-element list of that value and an integer. Inference produced
-that, and it has been running the whole time.
+It takes a value of any type `T` and returns a two-element list of that value and an integer.
+Inference produced that, and it runs whether or not type errors are reported.
 
-One thing is still off by default: reporting the places where those types disagree.
+Reporting the places where those types disagree is what is off by default:
 
 ```toml
 # ry.toml
@@ -171,12 +172,12 @@ error[type-mismatch]: expected a numeric value (`integer` or `double`), found `i
       ^^^^^
 ```
 
-One line of configuration, no annotations, no change to the code.
+That took one line of configuration, no annotations, and no change to the code.
 
-Type checking a whole project sounds expensive, and this is where it would show. It does not, because
-analysis is incremental: an edit re-checks only what that edit could have affected, not the project.
-ry is tested against roughly 970,000 lines of real R — 69 CRAN packages plus R's base library.
+Type checking a whole project is affordable because analysis is incremental: an edit re-checks only
+what that edit could have affected, not the project. ry is tested against roughly 970,000 lines of
+real R — 69 CRAN packages plus R's base library.
 
 - [Tutorial](/type-checking/tutorial) — put it on real code
 - [Concepts](/type-checking/concepts) — how it works out what it knows
-- [Adopting an existing codebase](/guides/adopting) — turning it on without drowning
+- [Adopting an existing codebase](/guides/adopting) — turning it on a piece at a time

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -7,7 +7,8 @@ ry is a toolchain for R, written in Rust. It is four tools in one binary:
 
 1. **A language server** — hover, completion, go-to-definition, references, rename, and inlay hints,
    in any editor that supports LSP.
-2. **A formatter** — a single consistent style, with almost no configuration.
+2. **A formatter** — a single consistent style; no configuration beyond indent width and line
+   endings.
 3. **An R console** — a REPL with project-aware completion.
 4. **A type checker** — optional; its inferred types also power the editor features.
 
@@ -38,13 +39,13 @@ warning[unresolved]: I could not resolve `ratee` in this package, its imports, o
 1 problem in 1 file
 ```
 
-One transposed letter, found without running anything. R would have found it too — halfway through the
-job, on whichever machine ran it first.
+One transposed letter, found without running anything. R reports the same mistake only when
+execution reaches that line.
 
 ## Now turn on the type checker
 
-Fix the typo and make a different mistake — the kind no linter can catch, because it needs to know what
-a value *is*:
+Fix the typo and make a different mistake — one no linter can catch, because catching it requires
+knowing what a value *is*:
 
 ```toml
 # ry.toml
@@ -63,9 +64,9 @@ error[type-mismatch]: expected `double`, found `character`
                         ^^^^^
 ```
 
-Nothing was annotated. ry worked out that `rate` is a number because you multiply by it — and
-that same knowledge is what makes hover, completion, and the console's tab completion useful. It runs
-whether or not you turn the errors on.
+Nothing was annotated. ry worked out that `rate` is a number because you multiply by it, and that
+same knowledge is what hover, completion, and the console's tab completion read. It runs whether or
+not you turn the errors on.
 
 ## Install
 

--- a/docs/src/content/docs/guides/adopting.md
+++ b/docs/src/content/docs/guides/adopting.md
@@ -1,16 +1,16 @@
 ---
 title: Adopting an existing codebase
-description: How to turn type checking on for a project that has never had it, without drowning in findings
+description: How to turn type checking on for a project that has never had it, without being buried in findings
 ---
 
 Turning `typing = true` on a codebase that has never been type-checked will report findings, possibly
-many. That is not a reason to avoid it. It is a reason to do it in four steps rather than one.
+many. That is a reason to do it in four steps rather than one.
 
 ## 1. Start with no configuration at all
 
-Code analysis needs no opt-in. Run `ry check` with no `ry.toml` and read what comes back —
-unresolved names, unused bindings, and duplicate definitions find real mistakes on day one, and none of
-them require you to understand the type system.
+Code analysis needs no opt-in. Run `ry check` with no `ry.toml` and read what comes back.
+Unresolved names, unused bindings, and duplicate definitions find real mistakes on day one, and none
+of them require you to understand the type system.
 
 Fix those first. It is a short list on most projects, and it clears the noise before you add more.
 
@@ -22,7 +22,7 @@ Fix those first. It is a short list on most projects, and it clears the noise be
 typing = true
 ```
 
-Resist fixing anything on the first pass. Read the whole list instead. On real code it collapses into a
+Do not fix anything on the first pass. Read the whole list instead. On real code it collapses into a
 handful of shapes, and recognizing the shape is worth more than fixing the first instance:
 
 | Shape | What it usually means |
@@ -31,8 +31,8 @@ handful of shapes, and recognizing the shape is worth more than fixing the first
 | An empty-list accumulator that later gains fields | `x <- list()` then `x$a <- 1`. The checker sees an empty list. Annotate the accumulator |
 | A value inferred as something other than a function, being called | Usually a name that shadows a function, or a dynamic construction the checker cannot follow |
 
-None of these mean your code is wrong. They mean the checker could not convince itself, which is a
-different claim.
+None of these mean your code is wrong. They mean the checker could not establish that it is right,
+which is a different claim.
 
 ## 3. Move file by file
 
@@ -47,9 +47,9 @@ overrides the project setting in both directions:
 # typing: off
 ```
 
-So you can leave `typing = false` project-wide and opt in the modules you are actively working on, or
-turn it on project-wide and exempt the files you are not ready for. Either way the setting travels with
-the file, in the file, where the next person will see it.
+So you can leave `typing = false` project-wide and opt in the modules you are actively working on,
+or turn it on project-wide and exempt the files you are not ready for. Either way the setting
+travels with the file, in the file, where the next person will see it.
 
 Work outward from the code you trust least or change most.
 
@@ -61,16 +61,16 @@ typing = true
 strict = true
 ```
 
-Strict mode is a much stronger claim than `typing = true`. It reports every place a value became
+Strict mode is a stronger claim than `typing = true`. It reports every place a value became
 `Unknown` — every point where the checker gave up rather than concluded something.
 
-That is exactly what you want on a module you intend to rely on, and exactly what you do not want
-across a whole legacy codebase on day one. A clean ordinary run means "I found no contradictions". A
-clean strict run means "I understood everything". Only the second is a guarantee.
+That is what you want on a module you intend to rely on, and not what you want across a whole legacy
+codebase on day one. A clean ordinary run means the checker found no contradictions. A clean strict
+run means it understood everything. Only the second is a guarantee.
 
-Strict mode is also the honest way to find out how much of a file is really being checked. Because
-`Unknown` is compatible with everything, a data-frame-heavy file can pass cleanly while barely being
-checked at all — see [limitations](/type-checking/limitations).
+Strict mode is also how you find out how much of a file is really being checked. Because `Unknown`
+is compatible with everything, a data-frame-heavy file can pass cleanly while barely being checked
+at all — see [limitations](/type-checking/limitations).
 
 ## Where the annotations go
 

--- a/docs/src/content/docs/guides/continuous-integration.md
+++ b/docs/src/content/docs/guides/continuous-integration.md
@@ -34,9 +34,9 @@ jobs:
 Both commands exit `1` on findings, which is what fails the job. Neither needs R installed.
 
 **Pin the version.** Every release so far is marked a pre-release, so
-`releases/latest/download/…` resolves to an old stable tag rather than the newest build — and the type
-system is still gaining capability, so a newer version can report findings an older one did not. Name
-the tag explicitly, as above. See [project status](/why-ry#project-status).
+`releases/latest/download/…` resolves to an old stable tag rather than the newest build. The type
+system is also still gaining capability, so a newer version can report findings an older one did
+not. Name the tag explicitly, as above. See [project status](/why-ry#project-status).
 
 Asset names follow the Rust target triple — `ry-aarch64-apple-darwin.tar.gz`,
 `ry-x86_64-pc-windows-gnu.zip` — and each archive contains the single `ry` binary.
@@ -46,15 +46,16 @@ Asset names follow the Rust target triple — `ry-aarch64-apple-darwin.tar.gz`,
 The default is strict: **warnings fail the job**. A run with nothing but `unused` warnings still
 exits `1`.
 
-That is usually right for a project that starts clean, and wrong for one adopting ry on an
-existing codebase. To gate on errors only while you work through a backlog:
+That is usually right for a project that starts clean, and wrong for one adopting ry on an existing
+codebase. To gate on errors only while you work through a backlog:
 
 ```bash
 ry check --min-severity error
 ```
 
-The filter applies before the exit code is decided, so warnings still print but no longer fail
-anything.
+The filter applies before anything is reported, so warnings are neither printed nor counted toward
+the exit code. A run whose only findings are warnings prints `1 file checked, no problems` and exits
+`0`.
 
 | You want | Command |
 | --- | --- |
@@ -63,9 +64,9 @@ anything.
 | Formatting enforced | `ry fmt --check` |
 | To see the diff CI would apply | `ry fmt --diff` |
 
-Be careful reading exit code `2` as "worse than 1" — it is a *different* failure. It means the run
-could not be completed: an unparseable `ry.toml`, a path that does not exist, an unreadable file.
-A job that treats any non-zero as "findings" will report a broken config as a code problem. The full
+Exit code `2` is not "worse than 1" — it is a *different* failure. It means the run could not be
+completed: an unparseable `ry.toml`, a path that does not exist, an unreadable file. A job that
+treats any non-zero status as "findings" will report a broken config as a code problem. The full
 table is in the [CLI reference](/reference/cli#exit-codes).
 
 ## JSON output
@@ -82,9 +83,9 @@ anything out.
 {"code":"type-mismatch","column":21,"endColumn":27,"endLine":4,"line":4,"message":"expected `integer`, found `character`","path":"/home/you/demo/main.R","related":[],"severity":"error"}
 ```
 
-Every field is documented in the [CLI reference](/reference/cli#json-output), and the field names are a
-contract — they are covered by tests that fail when they change, so a script built on them will not
-break silently.
+Every field is documented in the [CLI reference](/reference/cli#json-output), and the field names
+are a contract — they are covered by tests that fail when they change, so a script built on them
+will not break silently.
 
 Counting errors for a summary line, without jq:
 
@@ -95,5 +96,5 @@ ry check --output json | grep -c '"severity":"error"'
 ## Adopting on an existing project
 
 Do not start by putting `ry check` in front of a merge gate on a codebase that has never run it.
-Land the tool first, gate second. [Adopting an existing codebase](/guides/adopting) walks through the
-order that works.
+Land the tool first, gate second. [Adopting an existing codebase](/guides/adopting) walks through
+the order that works.

--- a/docs/src/content/docs/guides/r-console.md
+++ b/docs/src/content/docs/guides/r-console.md
@@ -1,6 +1,6 @@
 ---
 title: Working in the R console
-description: Run a real R session inside ry, with Tab completion that knows your types
+description: Run a real R session inside ry, with Tab completion backed by the type checker
 ---
 
 `ry repl` gives you an R prompt whose Tab completion comes from ry's type checker, and
@@ -13,7 +13,7 @@ process, and hands control to R's real main loop. Everything R does, R still doe
 autoprinting, error messages, `browser()`, `readline()`, S4 dispatch. Your `.Rprofile` is sourced.
 Packages install and attach normally.
 
-What ry replaces is the *line editor* in front of R. That is where the difference shows up:
+What ry replaces is the *line editor* in front of R. That is where the two differ:
 
 ```
 $ ry repl
@@ -25,10 +25,10 @@ balance  double
 holder   character
 ```
 
-R's own console can complete `account$balance` because by the time you press Tab the object exists in
-memory. ry reaches the same answer by type-checking what you have typed so far, which also lets
+R's own console can complete `account$balance` because by the time you press Tab the object exists
+in memory. ry reaches the same answer by type-checking what you have typed so far, which also lets
 it show that `balance` is a `double`, complete full signatures, and complete names inside `#:`
-annotations. The trade-off: **completion never inspects the live R session.**
+annotations. The trade-off is that **completion never inspects the live R session.**
 
 The console is also the only part of ry that needs R at all — see [What needs R](#what-needs-r).
 
@@ -56,7 +56,7 @@ To pin a specific R, set `R_HOME` for the one command:
 R_HOME=/opt/R/4.5.1/lib/R ry repl
 ```
 
-Startup problems fail immediately and say what to do, with exit status 2:
+Startup problems fail immediately and name the cause, with exit status 2:
 
 ```
 $ ry run analysis.R
@@ -66,16 +66,16 @@ $ R_HOME=/nonexistent ry run analysis.R
 error: R_HOME is set to /nonexistent, but that directory does not exist
 ```
 
-One hard requirement beyond "R is installed": it must have been built as a shared library
-(`--enable-R-shlib`). Every CRAN binary distribution is. If yours is not, ry says so and names the
-directory it looked in.
+There is one requirement beyond "R is installed": it must have been built as a shared library
+(`--enable-R-shlib`). Every CRAN binary distribution is. If yours is not, ry reports that and names
+the directory it looked in.
 
 R 4.2 or newer is what this is developed and tested against, and it is required on Windows. Nothing
-checks the version, so an older R will simply fail at load time with a missing-symbol error rather than
-a clear message.
+checks the version, so an older R fails at load time with a missing-symbol error rather than a clear
+message.
 
 Sessions start clean and leave nothing behind: no `.RData` is restored on the way in, and nothing is
-saved on the way out. `ry repl` also needs a terminal — piping into it does nothing useful, since
+saved on the way out. `ry repl` also needs a terminal — piping into it does nothing useful, because
 the editor cannot run and the session immediately sees end of input. Use `ry run` for anything
 non-interactive.
 
@@ -91,9 +91,9 @@ nzchar                              fn(x: Any, [keepNA]: logical) -> logical
 getDLLRegisteredRoutines.character  From the `base` package.
 ```
 
-The first two have typed [stubs](/type-checking/stubs) shipped with ry, so you get the full
-signature and which arguments are optional (`[type]`). The third is a real `base` export with no stub
-yet, so you get the name and its package. Tab again to cycle, Enter to accept.
+The first two have typed [stubs](/type-checking/stubs) shipped with ry, so the full signature and
+the optional arguments (`[type]`) are shown. The third is a real `base` export with no stub yet, so
+only the name and its package are shown. Tab again to cycle, Enter to accept.
 
 Six kinds of completion are available:
 
@@ -125,23 +125,23 @@ subsequence (which needs three characters). Names you defined outrank standard-l
 
 ### Three things it will not complete
 
-Completion is static analysis over the session transcript, and only that transcript. Each of these looks
-like a bug the first time:
+Completion is static analysis over the session transcript, and only that transcript. The
+consequences are:
 
 - **Objects R knows about but ry never saw you type.** Anything created by `source()` or defined in
   a file you passed to `-f` is invisible to Tab. `ry repl -f setup.R` feeds the script straight to
-  R, so `compound()` from that file runs fine but does not complete. Paste the definition into the
-  prompt if you want it completed.
+  R, so `compound()` from that file runs but does not complete. Paste the definition into the
+  prompt to have it completed.
 - **Your project's files and `ry.toml`.** The console analyzes one document — the session. It does
   not read your working directory, your project sources, or your `stubs/*.Rtypes` overrides. Use the
   [language server](/features) for typed work inside project files.
-- **Third-party packages.** Only the standard library is available. `library(dplyr)` attaches dplyr in R
-  as usual, but `dplyr::muta` + Tab still offers nothing typed — activating those stubs needs project
-  metadata that a console session does not have.
+- **Third-party packages.** Only the standard library is available. `library(dplyr)` attaches dplyr
+  in R as usual, but `dplyr::muta` + Tab offers nothing typed: activating those stubs needs project
+  metadata a console session does not have.
 
 ## Editing
 
-The editor is ry's, and it behaves the way a modern shell does.
+The editor is ry's, and its keys follow the conventions of a modern shell.
 
 | Key | Effect |
 | --- | --- |
@@ -169,11 +169,11 @@ Multi-line input is one editable buffer, not a sequence of lines you can no long
 ```
 
 ry decides a line is incomplete from the syntax alone — an open bracket, a trailing operator, a
-dangling comma, an unclosed string. It is deliberately conservative: if it guesses "complete" and R
-disagrees, R asks for the rest with its own `+` prompt and nothing is lost.
+dangling comma, an unclosed string. It is deliberately conservative: if it treats a line as complete
+and R disagrees, R asks for the rest with its own `+` prompt and nothing is lost.
 
-Every prompt R produces passes through unchanged, because ry does not render prompts of its own. So
-debugging works exactly as you expect:
+Every prompt R produces passes through unchanged, because ry renders no prompts of its own, so
+debugging behaves as it does in stock R:
 
 ```
 > f <- function(x) { browser(); x * 2 }
@@ -214,8 +214,8 @@ $ echo $?
 0
 ```
 
-An error at top level halts the script and fails the run — the same halt-on-error contract `Rscript`
-gives you:
+An error at top level halts the script and fails the run, the same halt-on-error contract `Rscript`
+has:
 
 ```
 $ ry run report.R     # cat("before\n"); stop("rate table is empty"); cat("after\n")
@@ -229,7 +229,7 @@ $ echo $?
 stops there, and the status is 1. An explicit `q(status = 7)` in your script passes straight through.
 For the full status table, see the [CLI reference](/reference/cli).
 
-Four things to know before you reach for it as an `Rscript` replacement:
+Four things to know before using it as an `Rscript` replacement:
 
 - **`ry run` does no analysis.** No type checking, no findings, no diagnostic codes — the bytes go
   to R. Run [`ry check`](/reference/cli) if you want the script checked.
@@ -239,8 +239,8 @@ Four things to know before you reach for it as an `Rscript` replacement:
 - **If your script sets its own `options(error = ...)`, it replaces the handler that produces the
   failing exit status**, and a failing script may then exit 0.
 
-`ry repl -f FILE` uses the same feeding mechanism but keeps you at the prompt afterwards, which is
-the fastest way to load a scratch setup and start poking at it.
+`ry repl -f FILE` uses the same feeding mechanism but keeps you at the prompt afterwards, which
+loads a scratch setup before an interactive session.
 
 ## What needs R
 

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -3,16 +3,16 @@ title: Installation
 description: Every way to install ry, including the cases the quick path does not cover
 ---
 
-Most people are done in one click — see the install section of
-[getting started](/getting-started#install). This page is for everything else.
+The common paths are on the install section of
+[getting started](/getting-started#install). This page covers the remaining cases.
 
 ## VS Code
 
 The [ry extension](https://marketplace.visualstudio.com/items?itemName=felix-andreas.roughly)
 bundles the binary for **Linux x86_64, macOS aarch64, and Windows x86_64**.
 
-On any other architecture the extension installs but has no binary to run. Install the CLI separately
-and point the extension at it:
+On any other architecture the extension installs but has no binary to run. Install the CLI
+separately and point the extension at it:
 
 ```json
 // settings.json
@@ -53,8 +53,8 @@ curl -sSL https://github.com/felix-andreas/ry/releases/download/0.3.0-alpha/ry-x
 sudo mv ry /usr/local/bin/
 ```
 
-Name the tag explicitly. Every release so far is marked a pre-release, so `releases/latest/` resolves
-to an older stable tag rather than the newest build.
+Name the tag explicitly. Every release so far is marked a pre-release, so `releases/latest/`
+resolves to an older stable tag rather than the newest build.
 
 **From source**, if you have a [Rust toolchain](https://www.rust-lang.org/tools/install):
 
@@ -67,7 +67,8 @@ installs is `ry`.
 
 This is also the route for architectures without a prebuilt binary.
 
-**Planned:** a one-line installer, so neither a manual download nor a Rust toolchain is needed. No date.
+**Planned:** a one-line installer, so neither a manual download nor a Rust toolchain is needed. It
+is not scheduled.
 
 ## RStudio
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Every ry.toml key, discovery rule, and editor setting in one place
 ---
 
-Everything you can change about ry's behavior lives in one file, `ry.toml`; editor settings only say where the binary is.
+Everything you can change about ry's behavior lives in one file, `ry.toml`. Editor settings only say where the binary is.
 
 ## Project discovery
 
@@ -85,7 +85,7 @@ Type inference always runs — hover, inlay hints, and signature help work regar
 
 A `# typing: off`, `# typing: on`, or `# typing: strict` line at the top of a file replaces both `typing` and `strict` for that file — see [the per-file directive](/reference/type-system#per-file-directive).
 
-Four things worth knowing about `exclude`:
+Four rules govern `exclude`:
 
 - Patterns are anchored at the directory holding `ry.toml`, and follow gitignore rules: `scripts/` excludes that whole subtree, `**/generated` matches at any depth, `!` re-includes.
 - Excluded directories are pruned without being walked, so exclusion cuts checking time, not just output.
@@ -107,11 +107,12 @@ warning[unused]: `v` is assigned but never used.
 
 ## Invalid and unknown keys
 
-An unknown key is never fatal — a config written for a newer ry still starts an older one.
+An unknown key is never fatal, so a config written for a newer ry still starts an older one.
 
 | Situation | Result |
 | --- | --- |
 | Unknown key | Ignored, with one warning naming it. Known keys beside it still load, and the exit code is unaffected. |
+| Known key at the wrong level | Ignored, with a warning naming the table it belongs under. A `typing = true` written outside `[check]` sets nothing. |
 | Wrong type on a known key | Hard error. |
 | Malformed TOML | Hard error. |
 | Invalid `[check] exclude` pattern | Hard error. |
@@ -129,7 +130,7 @@ typing = true
 [format]
 indent = 4
 $ ry check .
-warning: ignoring unknown config key `strict` — check the spelling, or update ry
+warning: ignoring config key `strict` — it belongs under `[check]`, and nothing outside a table sets it
 warning: ignoring unknown config key `check.stric` — check the spelling, or update ry
 warning: ignoring unknown config key `format.indent` — check the spelling, or update ry
 1 file checked, no problems

--- a/docs/src/content/docs/reference/diagnostic-codes.md
+++ b/docs/src/content/docs/reference/diagnostic-codes.md
@@ -3,7 +3,7 @@ title: Diagnostic codes
 description: Every code ry can emit, what triggers it, and how to silence it
 ---
 
-Every finding ry reports carries a stable code. This page lists all of them.
+Every finding ry reports carries a stable code. This page lists them all.
 
 ## How to read a finding
 
@@ -64,7 +64,7 @@ Several R idioms are recognized directly, with no comment needed:
 | A file that calls `R6Class` | `self`, `private` and `super` resolve in it |
 | A name created by `<<-` anywhere in the file | Resolves |
 | A name starting with `.` or `_` | Never reports `unused` |
-| `library(pkg)` for a package with no shipped stub | `unresolved` goes quiet, except for near misses of names your own project binds |
+| `library(pkg)` for a package with no shipped stub | `unresolved` is suppressed project-wide, except for near misses of names your own project binds |
 
 Formatting is suppressed by a different mechanism — `# fmt: skip`, `# fmt: off` / `# fmt: on`, `# fmt: skip-file`. See [formatting rules](/reference/formatting-rules).
 

--- a/docs/src/content/docs/reference/formatting-rules.md
+++ b/docs/src/content/docs/reference/formatting-rules.md
@@ -4,7 +4,7 @@ description: Every rule the formatter applies, with a before-and-after for each
 ---
 <!-- THIS FILE IS GENERATED AUTOMATICALLY.MAKE CHANGES TO crates/format/tests/formatter.template.md INSTEAD -->
 
-ry includes a non-invasive R code formatter that emphasizes readability while respecting the existing structure of your code.
+ry includes a non-invasive R code formatter. It normalizes spacing, indentation and bracing, and preserves the structure you wrote.
 
 ## Usage
 
@@ -17,22 +17,22 @@ ry fmt --check   # List files that would be reformatted, without writing
 ry fmt --diff    # Show a diff of formatting changes without applying them
 ```
 
-`--check` and `--diff` exit 1 when any file would change, so they slot straight into CI. Errors
+`--check` and `--diff` exit 1 when any file would change, which is what a CI job gates on. Errors
 (for example a file that cannot be parsed) exit 2 — see the full
 [exit-code table](/reference/cli#exit-codes).
 
 ## Philosophy
 
-ry's non-invasive approach means it respects your existing line breaks and won’t arbitrarily split expressions you’ve chosen to keep on one line. The formatter is guided by these principles:
+The formatter preserves existing line breaks and does not split expressions that are written on one line. Four principles follow from that:
 
-* **Single-line expressions remain single-line:** The formatter only adds line breaks if the expression is already multi-line, and will never break single-line expressions into multiple lines (with [one exception](#loops)).
-* **Flexible style preservation:** Both compact ("hugged") and expanded forms for nested expressions are supported, so your preferred style is respected (see [hugging behavior](#hugging-behavior)).
-* **Automatic braces only when needed:** Braces are added automatically only where they prevent subtle bugs (see [auto-bracing](#auto-bracing)).
-* **Minimal configuration:** The formatter works out of the box with sensible defaults, so you can use it immediately without extra setup (see [configuration](/reference/configuration)).
+* **Single-line expressions remain single-line:** The formatter adds line breaks only where the expression is already multi-line, and never breaks a single-line expression into several (with [one exception](#loops)).
+* **Both nesting styles are preserved:** Compact ("hugged") and expanded forms for nested expressions are equally valid, and neither is rewritten into the other (see [hugging behavior](#hugging-behavior)).
+* **Braces are added only where they prevent a bug:** Auto-bracing applies where omitting braces changes what a later edit means (see [auto-bracing](#auto-bracing)).
+* **Two configuration keys:** Indent width and line endings, both documented under [configuration](/reference/configuration). There are no style options, because a reflowing formatter would rewrite line breaks the author chose.
 
 ## Formatting Rules
 
-Below is a comprehensive list of rules describing the behavior of the formatter for different kinds of expressions, including edge cases where special handling is applied.
+The rules below describe the formatter's behavior for each kind of expression, including the edge cases that receive special handling.
 
 ### Binary Operators
 
@@ -228,7 +228,7 @@ if (
 
 Loops are the only expressions that are **not allowed** on a single line.
 
-Because `for`, `while`, and `repeat` loops are used solely for their side effects and do not return meaningful values, the formatter always requires these loops to be written across multiple lines with explicit braces (see [auto-bracing](#auto-bracing)). This ensures that side-effecting code is visually distinct from pure expressions.
+`for`, `while`, and `repeat` loops are evaluated for their side effects and return no meaningful value, so the formatter writes them across multiple lines with explicit braces (see [auto-bracing](#auto-bracing)). This keeps side-effecting code visually distinct from expressions that produce a value.
 
 **For loops** always enforce braced blocks for the body, ensuring consistency:
 
@@ -266,7 +266,7 @@ repeat {
 }
 ```
 
-**Multiline for loop headers:** The formatter allows both of the following styles for multiline `for` loop headers, preserving your preferred structure:
+**Multiline for loop headers:** Both of the following styles for multiline `for` loop headers are preserved:
 
 ```r
 for (
@@ -307,7 +307,7 @@ call(
 )
 ```
 
-**Nested function calls** can use either a hugged style—where the inner call starts right after the outer call's parenthesis—or an expanded style. Both are preserved by the formatter, letting you choose the most readable form for your code.
+**Nested function calls** can use either a hugged style — where the inner call starts directly after the outer call's parenthesis — or an expanded style. The formatter preserves both.
 
 ```r
 # Hugged format - both functions start on the same line
@@ -332,7 +332,7 @@ call(a = x, b = y, c = inner(
 ))
 ```
 
-This behavior is particularly useful for testing frameworks and S4 method definitions:
+This applies to testing frameworks and S4 method definitions:
 
 ```r
 test_that("description", {
@@ -392,7 +392,7 @@ lapply(data, \(x) {
 
 ### Switch Statements
 
-Switch statements are formatted like normal function calls. For fallthrough cases (e.g., `case = ,`), an extra space is added after the `=` to clearly indicate the fallthrough.
+Switch statements are formatted like ordinary function calls. For fallthrough cases (`case = ,`), an extra space is added after the `=` to mark the fallthrough.
 
 ```r
 result <- switch(
@@ -436,7 +436,7 @@ pkg::process
 pkg:::filter
 ```
 
-When chaining extract or namespace operators across multiple lines, the formatter indents each subsequent line to make the chain visually distinct and easy to follow:
+When an extract or namespace chain spans several lines, each subsequent line is indented one step:
 
 ```r
 # Before formatting
@@ -452,7 +452,7 @@ object$
 
 ### String Literals
 
-String literals receive intelligent quote normalization. The formatter prefers double quotes (`"`) unless the string contains unescaped double quotes:
+String literals are normalized to double quotes (`"`), unless the string contains unescaped double quotes:
 
 ```r
 # Before formatting
@@ -686,11 +686,11 @@ You can also skip formatting for an entire file by placing `# fmt: skip-file` at
 
 ## Rationale
 
-This section explains the key design decisions that guided the formatter's implementation.
+This section records the design decisions behind the rules above.
 
 ### Auto-Bracing
 
-**Accidental bugs:** It's easy to accidentally introduce subtle bugs when omitting braces in loops, function definitions, or `if` expressions. For example, if you later add a line after an unbraced `if`, only the first line is controlled by the condition:
+**Accidental bugs:** Omitting braces in loops, function definitions, or `if` expressions makes a later edit change what the code means. Adding a line after an unbraced `if` leaves only the first line under the condition:
 
 ```r
 # unbraced condition
@@ -732,7 +732,7 @@ for (item in sequence) {
 
 ### Hugging Behavior
 
-"Hugging" refers to how nested expressions are formatted in multiline contexts—keeping them compact by allowing inner expressions to start on the same line as the outer expression's opening delimiter. This is part of ry's non-invasive approach: both hugged and expanded formats are allowed.
+"Hugging" is the compact layout for a nested expression in a multiline context: the inner expression starts on the same line as the outer expression's opening delimiter. Both hugged and expanded forms are allowed, and the formatter preserves whichever was written.
 
 **Nested function calls** can be formatted in a hugged style:
 
@@ -763,4 +763,4 @@ result <- outer(
 )
 ```
 
-See the [compact multiline calls](#function-calls) section under Function Calls for more details. The formatter preserves this style, which is especially useful for S4 methods and testing frameworks.
+See [compact multiline calls](#function-calls) under Function Calls. This style is preserved, which is what keeps S4 methods and testing-framework calls intact.

--- a/docs/src/content/docs/reference/type-system.md
+++ b/docs/src/content/docs/reference/type-system.md
@@ -329,8 +329,7 @@ do not check against a shape the checker could not establish and one mistake doe
 a file. An item carrying an explicit **declaration** is the exception: a `#:` annotation is what the
 author says the binding is, and it stays that whether or not the body honours it. So a function whose
 body violates its annotation reports the body error *and* keeps checking every call site against the
-declared signature — otherwise a caller's mistake would stay hidden until the body was fixed, which
-inverts the order anyone works in.
+declared signature; otherwise a caller's mistake would stay hidden until the body was fixed.
 
 Unused (dead-store) analysis follows from the same reaching sets when the `unused` check is
 enabled: an assignment whose written value no read can observe on any path warns
@@ -503,8 +502,7 @@ This is an error because the checker already knows the type.
 `#: @trust TYPE` is a trusted coercion.
 
 - it tells the checker to treat the annotated value as `TYPE` without requiring ordinary compatibility at that annotation site
-- this is the “trust me bro” escape hatch
-- it is similar in spirit to TypeScript’s `as`
+- it is the unchecked escape hatch, similar in spirit to TypeScript’s `as`
 - conceptually, `#: @trust TYPE` is like coercing through `Any` and then to `TYPE`, but written directly because that is more ergonomic
 
 Examples:
@@ -675,7 +673,7 @@ Examples:
 - `list(1L, 2L, 3L)` currently infers as `list{integer, integer, integer}`, not `list[integer]`
 - `list(foo = 1L, bar = 2L)` currently infers as `list{foo: integer, bar: integer}`, not `list[named: integer]`
 
-This is not set in stone. If this default turns out to be awkward in practice, it may be reasonable to introduce distinct tuple and record constructors later, even if they remain runtime aliases of R lists.
+This default is provisional. If it proves awkward in practice, distinct tuple and record constructors may be introduced later, even if they remain runtime aliases of R lists.
 
 #### List coercions
 
@@ -1046,7 +1044,7 @@ as bare `@type NAME` — see [Standard library stubs](/type-checking/stubs). For
 
 - `$`, `[`, and `[[` are accepted and the result is `Unknown` rather than an error: the R object
   behind such a class commonly supports value-dependent access (`df$amount`, `df[rows, ]`), and
-  refusing would reject the most idiomatic R there is
+  refusing would reject ordinary R
 - the access is not checked further — no field-existence, index-count, or index-type checking —
   so `df[i, j]` and `df[rows, ]` both pass
 - every such access is an unsupported construct under [strict mode](#strict-mode): the untyped
@@ -1128,7 +1126,7 @@ Unification is the **invariant floor**: when it must produce a single representa
 
 ### Union types
 
-A union type `A | B | ...` describes a value that has one of the member types. Any number of members is allowed, and any type may be a member; `T | NULL` — the nullable form of `T` — is simply the two-member special case.
+A union type `A | B | ...` describes a value that has one of the member types. Any number of members is allowed, and any type may be a member; `T | NULL` — the nullable form of `T` — is the two-member special case.
 
 - union syntax is allowed anywhere a type can appear, including:
   - variable annotations
@@ -1235,7 +1233,7 @@ that admits:
   R rather than mistakes
 - `character`, `complex` and `raw` are type errors. R refuses `complex` and `raw` outright, and in
   a `character` condition it accepts only the spellings of `TRUE` and `FALSE` (`"T"`, `"true"`, …)
-  and raises at run time on every other string — so `if ("yes")` is a bug worth reporting
+  and raises at run time on every other string, so `if ("yes")` is reported
 - a **vector** is a type error: a condition whose length is not one is an error in R too
 - a condition whose type is still undetermined is bound to `logical`, the useful default for an
   unannotated predicate — so `function(flag) if (flag) 1L` infers `flag: logical`
@@ -1263,7 +1261,7 @@ Examples:
   - branches that unify share that type: `if (flag) 1L else 2L` is `integer`, and `if (cond) a else b` over two unconstrained values keeps them unified as one polymorphic type
   - a `NULL` branch joins by union without constraining the other branch: one branch `T` and one branch `NULL` produce `T | NULL`
   - branches with genuinely different types produce their union: `if (flag) 1L else "foo"` is `integer | character` — different branch types are **not** a type error
-  - a branch whose type is still an **unconstrained** inference variable is never pinned by the other branch: `function(flag, x) if (flag) x else "s"` is `<T> fn(flag: logical, x: T) -> T | character`, not `fn(flag: logical, x: character)`. Unifying there would make the *caller* wrong for a line that is not, and it is what the guard rule requires — the whole point of `if (is.character(x)) x else "other"` is that the caller may pass something else
+  - a branch whose type is still an **unconstrained** inference variable is never pinned by the other branch: `function(flag, x) if (flag) x else "s"` is `<T> fn(flag: logical, x: T) -> T | character`, not `fn(flag: logical, x: character)`. Unifying there would make the *caller* wrong for a line that is not, and it is what the guard rule requires: `if (is.character(x)) x else "other"` exists precisely because the caller may pass something else
   - a branch whose variable the body has already **constrained** may unify with the other, because that pin adds nothing the program did not already require: `function(n) if (n <= 1L) 1L else n * fact(n - 1L)` converges to `fn(n: integer) -> integer`
   - two branches that are **both** still open tie to each other, since neither pins the other: `function(value, fallback) if (is.null(value)) fallback else value` is `<T> fn(value: T | NULL, fallback: T) -> T`
   - an `Unknown` branch makes the whole conditional `Unknown` rather than claiming the other branch's type
@@ -1551,10 +1549,10 @@ call site:
 **Only a declaration file can overload a name**, and that boundary is deliberate. Overloading is the
 one place this type system departs from Hindley-Milner: a name with several signatures has no single
 most general type, so a call has to be *resolved by search* rather than inferred, which costs both
-the principal-type guarantee and the speed that comes with plain unification. That price is worth
-paying for a fixed, curated corpus describing a standard library nobody designed with types in mind,
-and it is not worth paying across a whole codebase. Two caveats on *why* the corpus needs sets, since
-they point at work rather than at a law: a family like `min`/`abs` is really one constrained,
+the principal-type guarantee and the speed that comes with plain unification. That cost is acceptable
+for a fixed, curated corpus describing a standard library nobody designed with types in mind, and
+unacceptable across a whole codebase. Two caveats on *why* the corpus needs sets, since they point at
+work rather than at a law: a family like `min`/`abs` is really one constrained,
 shape-preserving scheme (`<T: numeric> fn(x: T) -> T`) written out longhand, because the declaration
 grammar cannot yet express a constrained binder or a shape-mirroring return. Closing those two gaps
 would collapse a large share of the corpus's sets into single signatures. So a
@@ -1697,8 +1695,8 @@ unconstrained. Reading fields, elements, and slices off a value whose shape the 
 down is how idiomatic R walks recursive and generic data (a tree fold, a generic accessor), so
 refusing here would flag ordinary code. The access is instead sound-by-refusal and surfaced as an
 unsupported construct under [strict mode](#strict-mode), exactly as for an opaque nominal. This
-covers **multi-index** subsetting too: `function(m, i, j) m[i, j]` is silent, because the whole point
-of that function is that the caller knows the shape and the callee does not. A subject whose shape
+covers **multi-index** subsetting too: `function(m, i, j) m[i, j]` is silent, because such a function
+is written for a caller that knows the shape when the callee does not. A subject whose shape
 *was* written down still refuses a shape no rule covers — `c(1L, 2L)[1L, 2L]` is an error.
 Recovering the field or element type by constraining the variable to a record-with-field or
 indexable shape is future work.
@@ -2429,7 +2427,7 @@ apply_renderer <- function(render_count, count) { render_count(count) }
 
 ry checks the parts of R's object systems that are **written down as declarations**, and
 declines the parts that are **decided at run time from a value's class attribute**. The boundary is
-deliberate, not a to-do list, so this section states both what happens and why.
+deliberate rather than pending work, so this section states both what happens and why.
 
 | Construct | What the checker does |
 | --- | --- |
@@ -2443,18 +2441,18 @@ deliberate, not a to-do list, so this section states both what happens and why.
 | `self` / `private` / `super` inside an R6 method | Resolve as names, type as `Unknown` |
 
 `x@slot` reads (and `x@slot <- v` writes) an S4 object slot. The slot's type is unknown, but the
-construct is not a hole:
+construct is still analyzed:
 
 - a slot read types as `Unknown` and is a strict-mode origin
 - the subject expression is inferred, so its own type errors surface
 - the subject's variable read counts for naming, unused analysis, references, and rename
 - a slot write is an ordinary replacement-form assignment of its base variable
 
-### You can give your own classes a checked type today
+### Declaring a checked type for your own classes
 
-A class is a nominal with a representation, and that is [something you can
+A class is a nominal type with a representation, which is [something you can
 declare](#type-parameters-aliases-and-nominal-types). Wrapping the constructor is enough to get
-slot types, constructor arity, and field access checked on an S4 or R6 class right now:
+slot types, constructor arity, and field access checked on an S4 or R6 class:
 
 ```r
 #: @type Point {list{x: double, y: double}}
@@ -2548,8 +2546,8 @@ Unresolved references carry the `unresolved` diagnostic code:
 
 Outside strict mode these are warnings. Under strict (configured, or via the per-file directive)
 they are **errors**: a name the checker cannot see is a hole in the checked surface, not a hint. So
-turning strict on can raise the severity of findings that were already there, without their count
-changing — worth knowing before a `--min-severity error` gate sees them.
+turning strict on can raise the severity of findings that were already there without changing their
+count, which matters when a `--min-severity error` gate reads them.
 
 Two `unresolved` findings are errors whatever the mode, because they stop the package from loading
 rather than describing a gap in the checker's view: a `NAMESPACE` `importFrom` naming something the
@@ -2654,9 +2652,9 @@ declaration whose only parameter is `...` (`join_by : @masked fn(...: Any) -> An
 argument. A locally defined function of the same name masks nothing, and `@masked` on a
 non-variadic declaration is a stub error.
 
-A file that calls `R6Class` gets `self`, `private` and `super` for free inside it: R6 builds those
+A file that calls `R6Class` resolves `self`, `private` and `super` inside it: R6 builds those
 bindings at construction, so they resolve nowhere lexically and a read of one is not an unresolved
-name, exactly as `this` is not one in a JavaScript class. The recognition is syntactic (a local
+name, in the same way `this` is not one in a JavaScript class. The recognition is syntactic (a local
 binding shadowing `R6Class` is not honored) and file-scoped — a file that defines no R6 class still
 warns about `self`. Their type is `Unknown` for now; R6 field and method types are not yet modelled.
 

--- a/docs/src/content/docs/type-checking/concepts.md
+++ b/docs/src/content/docs/type-checking/concepts.md
@@ -5,7 +5,8 @@ description: How ry's type system works — the vocabulary you need to read what
 
 ## Inference
 
-**Inference** is the checker working out a type instead of being told one. What a value must be follows from what you do with it.
+**Inference** is the checker working out a type instead of being told one. What a value must be
+follows from what you do with it.
 
 ```r
 scale <- function(x, factor) {
@@ -13,16 +14,16 @@ scale <- function(x, factor) {
 }
 ```
 
-`*` is arithmetic, so `x` and `factor` are numbers. That is inferred, not declared, and it is enough to
-reject `scale("a", 2)`.
+`*` is arithmetic, so `x` and `factor` are numbers. That is inferred, not declared, and it is enough
+to reject `scale("a", 2)`.
 
-You annotate where you want to say something the code does not already
-say — a boundary, a domain type, a promise you want held to.
+You annotate where you want to state something the code does not already state — a boundary, a
+domain type, a promise you want held to.
 
 ## Scalars and vectors
 
-In R, `1L` is an integer vector of length one. There is no separate scalar type, which means the type
-system has to choose a convention. ry's is:
+In R, `1L` is an integer vector of length one. There is no separate scalar type, so the type system
+has to choose a convention. ry's is:
 
 | Notation | Means |
 | --- | --- |
@@ -32,9 +33,9 @@ system has to choose a convention. ry's is:
 
 Literals are scalars. `1L` is `integer`, not `integer[]`.
 
-The relationship between them is **one-way**: a scalar is accepted where a vector is expected, because
-a length-one vector is a vector. The reverse is not — a vector of unknown length is not accepted where
-a single value is required, because it might have length zero, or seven.
+The relationship between them is **one-way**: a scalar is accepted where a vector is expected,
+because a length-one vector is a vector. The reverse is not, because a vector of unknown length
+might have length zero, or seven.
 
 ## Atomic types
 
@@ -46,18 +47,18 @@ Four of them form a ladder, and values widen up it implicitly:
 logical  <  integer  <  double  <  complex
 ```
 
-So an `integer` is accepted where a `double` is wanted. `character` and `raw` are deliberately **not**
-on the ladder — R will happily coerce a number to a string, but doing it silently is almost always a
-mistake rather than an intention, so ry makes you say it.
+So an `integer` is accepted where a `double` is wanted. `character` and `raw` are deliberately
+**not** on the ladder: R coerces a number to a string, but doing so silently is more often a mistake
+than an intention, so ry requires you to write the conversion.
 
-Widening happens only when checking whether a value *fits* somewhere. It never happens when the checker
-is working out what two things have in common — that is a different question, and answering it by
-widening would quietly lose information.
+Widening happens only when checking whether a value *fits* somewhere. It never happens when the
+checker is working out what two things have in common — that is a different question, and answering
+it by widening would discard information.
 
 ## Lists
 
-R gives you one `list()` and expects you to use it for everything. In practice you use it for at least
-four different jobs, and the mistakes you can make with each are different:
+R gives you one `list()` and expects you to use it for everything. In practice it does at least four
+different jobs, and the mistakes available in each are different:
 
 | What you are building | Type | Example |
 | --- | --- | --- |
@@ -66,24 +67,24 @@ four different jobs, and the mistakes you can make with each are different:
 | A growable sequence, all one type | `list[integer]` | results you `append()` to in a loop |
 | A lookup table keyed by name | `list[named: integer]` | counts by category |
 
-The split that matters is **fixed shape** versus **unknown shape**. `list{...}` means the checker knows
-exactly which elements exist, so it can check `$` and `[[`. `list[...]` means it knows the element type
-but not how many there are, so it cannot.
+The distinction that matters is **fixed shape** versus **unknown shape**. `list{...}` means the
+checker knows exactly which elements exist, so it can check `$` and `[[`. `list[...]` means it knows
+the element type but not how many there are, so it cannot.
 
 Atomic vectors have the same two shapes: `integer` is one value, `integer[]` is many.
 
-**None of this changes anything at runtime.** All four are an ordinary R `list`; `is.list()` is `TRUE`
-for every one, `str()` prints what it always printed, and there is nothing to migrate. The distinction
-exists only so the checker can tell you which of the four you actually built.
+**None of this changes anything at runtime.** All four are an ordinary R `list`; `is.list()` is
+`TRUE` for every one, `str()` prints what it always printed, and there is nothing to migrate. The
+distinction exists so the checker can tell you which of the four you built.
 
-That is what makes `$` safe:
+That is what makes `$` checkable:
 
 ```r
 person <- list(fullname = "Ada", age = 36L)
 person$fullnme
 ```
 
-The literal has a fixed shape, so the checker knows the field is not there — instead of the silent
+The literal has a fixed shape, so the checker knows the field is not there, instead of the silent
 `NULL` you get at runtime:
 
 ```text
@@ -92,14 +93,14 @@ error[type-mismatch]: field `fullnme` does not exist in `list{fullname: characte
 
 ## Functions
 
-A function type is written the way you would say it out loud:
+A function type is written in the order you would say it:
 
 ```
 fn(x: integer, y: character) -> logical
 ```
 
-Optional parameters — those with defaults — are marked, and parameter **names** are part of the type,
-because R calls functions by name as often as by position.
+Optional parameters — those with defaults — are marked, and parameter **names** are part of the
+type, because R calls functions by name as often as by position.
 
 ## Unions and `NULL`
 
@@ -109,38 +110,37 @@ A value that could be one of several things has a union type, written with `|`:
 integer | character
 ```
 
-You have already seen one: when a variable is assigned different types on different branches, its type
-after the `if` is the union of both. That is what the type checker reports in the
+You have already seen one: when a variable is assigned different types on different branches, its
+type after the `if` is the union of both. That is what the type checker reports in the
 [Features](/features) example.
 
-`NULL` is its own type, and this is where unions matter most. A function that may return nothing
-has type `character | NULL`, and using that result as a `character` without checking is an error — the
+`NULL` is its own type, and this is where unions matter most. A function that may return nothing has
+type `character | NULL`, and using that result as a `character` without checking is an error — the
 missing `if (is.null(x))` that would have failed at runtime.
 
 ## `Any` and `Unknown`
 
-Both accept anything and are accepted anywhere. They exist as two names because the *reason* differs,
-and the reason is what you need to know:
+Both accept anything and are accepted anywhere. They exist as two names because the *reason* they
+arise differs, and the reason is what you need to know:
 
 | | Means |
 | --- | --- |
 | `Unknown` | **The checker could not work it out.** A gap in its knowledge |
-| `Any` | **You said not to care.** A deliberate opt-out you wrote |
+| `Any` | **You declared that it does not matter.** A deliberate opt-out you wrote |
 
-This matters more than it looks. Because `Unknown` is compatible with everything, one construct the
-checker cannot model does not cascade into a screen of errors — it just goes quiet. That is what keeps
-the tool usable on real R. It also means a clean run does not by itself tell you how much was actually
-checked.
+Because `Unknown` is compatible with everything, one construct the checker cannot model does not
+cascade into a screen of errors; it produces no findings at all. That is what keeps the tool usable
+on real R. It also means a clean run does not by itself tell you how much was checked.
 
-[Strict mode](#typing-modes) is the answer to that: it reports every place a value became `Unknown`, so
-you can see the gaps instead of mistaking them for approval.
+[Strict mode](#typing-modes) addresses that: it reports every place a value became `Unknown`, so the
+gaps are visible instead of looking like approval.
 
 ## Naming your own types
 
 ### `@type`
 
-Start with the case you actually have: a thing in your domain with named fields. In R you would reach
-for S4, R6 or S7. ry gives you a third option that the checker can see into:
+Start with the common case: a thing in your domain with named fields. In R you would reach for S4,
+R6 or S7. ry offers a third option that the checker can see into:
 
 ```r
 #: @type Person {list{name: character, age: integer}}
@@ -155,8 +155,8 @@ new_person <- function(name, age) {
 greet <- function(p) paste0("hi ", p$name)
 ```
 
-A `Person` is an ordinary named list at runtime — no class system, no dispatch, no dependency. But it
-is a **distinct type** to the checker, so `greet` accepts a `Person` and nothing else:
+A `Person` is an ordinary named list at runtime — no class system, no dispatch, no dependency. To
+the checker it is a **distinct type**, so `greet` accepts a `Person` and nothing else:
 
 ```r
 greet(list(name = "Bob", age = 40L))
@@ -166,26 +166,26 @@ greet(list(name = "Bob", age = 40L))
 error[type-mismatch]: expected `Person`, found `list{name: character, age: integer}`
 ```
 
-Read that error carefully, because it is the whole idea. The list has *exactly* the right fields with
-exactly the right types, and it is still rejected. Matching the shape is not enough — you have to have
-gone through the door:
+The list has exactly the right fields with exactly the right types, and it is still rejected.
+Matching the shape is not sufficient; the value has to have been introduced as a `Person`:
 
 ```r
 #: @new Person
 ada <- list(name = "Ada", age = 36L)
 ```
 
-`@new` is that door. It checks the value against the declared representation and hands back the nominal
-type. Put it inside a constructor, as `new_person` does, and every `Person` in your program provably
+`@new` is the only way in. It checks the value against the declared representation and returns the
+nominal type. Put it inside a constructor, as `new_person` does, and every `Person` in your program
 came from there.
 
-This is **nominal** safety, as opposed to the **structural** kind. Structural typing asks "does it have
-the right shape?"; nominal typing asks "is it the thing?". S4 and R6 answer that question at run time and tell the
-checker nothing. `@type` answers it at analysis time and adds nothing at run time.
+This is **nominal** typing, as opposed to **structural**. Structural typing asks "does it have the
+right shape?"; nominal typing asks "is it the thing?". S4 and R6 answer that question at run time
+and tell the checker nothing. `@type` answers it at analysis time and adds nothing at run time.
 
 ### Two names for the same shape
 
-Nominal types matter most when two values have the same shape but must not be swapped:
+Nominal types matter most when two values have the same shape but must not be substituted for each
+other:
 
 ```r
 #: @type Celsius {double}
@@ -209,9 +209,9 @@ to_fahrenheit(warm)
 error[type-mismatch]: expected `Celsius`, found `Fahrenheit`
 ```
 
-The last line converts an already-converted temperature — the bug every unit mix-up is. Both types are
-`double` underneath, and arithmetic on them still works, because the representation is visible
-*outward*. What does not happen is a bare `double`, or the other unit, arriving where one is expected.
+The last line converts an already-converted temperature. Both types are `double` underneath, and
+arithmetic on them still works, because the representation is visible *outward*. What cannot happen
+is a bare `double`, or the other unit, arriving where one of them is expected.
 
 ### `@alias`
 
@@ -221,15 +221,19 @@ Sometimes you want the opposite: a shorthand that stays interchangeable with wha
 #: @alias Row {list{id: integer, label: character}}
 ```
 
-`Row` expands to its body everywhere, so a `Row` and that list are the same type. Use it to stop
-repeating a long type; use `@type` when being confused with the underlying value is the thing you are
+`Row` expands to its body everywhere, so a `Row` and that list are the same type. Use it to avoid
+repeating a long type; use `@type` when being confused with the underlying value is what you are
 trying to prevent.
 
 :::note
-A `#:` block does one thing: it declares types (`@type`, `@alias`) **or** it annotates the item on the
-next line. Run them together and you get
-`error[annotation]: @type and @alias declarations need their own #: block`. Separate them with a blank
-line, as above.
+A `#:` block does one thing: it declares types (`@type`, `@alias`) **or** it annotates the item on
+the next line. Running them together reports:
+
+```text
+error[annotation]: `@type` and `@alias` declarations need their own `#:` block — separate them from other annotations with a blank line.
+```
+
+Separate them with a blank line, as above.
 :::
 
 See [domain modeling](/type-checking/domain-modeling) for constructors, validation, and when R6 is
@@ -248,12 +252,12 @@ greet <- function(name) {
 }
 ```
 
-After the guard, `name` is no longer `NULL` and `paste0` is happy.
+After the guard, `name` is no longer `NULL` and `paste0` accepts it.
 
-Narrowing is deliberately narrow. It happens on the condition of an `if`, and only for a guard applied
-directly to a plain variable. `if (is.null(x))` narrows `x`; `if (is.null(obj$field))` does not, and
-neither does a guard behind an `&&`. If a narrowing you expected did not happen, this is almost always
-why — lift the value into a local variable first.
+Narrowing is deliberately limited. It happens on the condition of an `if`, and only for a guard
+applied directly to a plain variable. `if (is.null(x))` narrows `x`; `if (is.null(obj$field))` does
+not, and neither does a guard behind an `&&`. If a narrowing you expected did not happen, this is
+almost always why — lift the value into a local variable first.
 
 ## Generics
 
@@ -264,17 +268,17 @@ constrains is generic automatically:
 identity2 <- function(x) x
 ```
 
-is `<T> fn(x: T) -> T` — it returns exactly what you gave it, whatever that was. Add one arithmetic
-operation and the checker narrows the promise on its own:
+is `<T> fn(x: T) -> T` — it returns exactly what it was given, whatever that was. Add one arithmetic
+operation and the checker narrows the type on its own:
 
 ```r
 increment <- function(x) x + 1L
 ```
 
-is `<T: numeric> fn(x: T) -> T`, which says "some number in, the same kind of number out". You do not
-have to ask for that, and there is nothing to maintain.
+is `<T: numeric> fn(x: T) -> T`: some number in, the same kind of number out. Neither has to be
+asked for, and neither has to be maintained.
 
-When you do want to write one, the binder goes at the front:
+When you do write one, the binder goes at the front:
 
 ```r
 #: <T> fn(items: list[T], index: integer) -> T
@@ -282,7 +286,7 @@ When you do want to write one, the binder goes at the front:
 
 ## Typing modes
 
-Three, and they are per file as well as per project:
+There are three, and they are per file as well as per project:
 
 | Mode | Reports |
 | --- | --- |
@@ -290,8 +294,8 @@ Three, and they are per file as well as per project:
 | `on` | Contradictions — places where the types genuinely disagree |
 | `strict` | Contradictions, plus every place a value became `Unknown` |
 
-Set the project default in [`ry.toml`](/reference/configuration), and override it in any single
-file with a comment at the top:
+Set the project default in [`ry.toml`](/reference/configuration), and override it in any single file
+with a comment at the top:
 
 ```r
 # typing: strict

--- a/docs/src/content/docs/type-checking/domain-modeling.md
+++ b/docs/src/content/docs/type-checking/domain-modeling.md
@@ -4,11 +4,11 @@ description: Give your domain its own checked types with nominal declarations, i
 ---
 
 R's object systems were designed for dispatch, not for static reasoning. This page shows what to use
-instead when what you want is for the checker to *know* what a value is.
+instead when what you want is for the checker to know what a value is.
 
 ## What the object systems give a checker
 
-Nothing, mostly. Here is an S4 class and an R6 class, and a function that only accepts strings:
+Very little. Here is an S4 class and an R6 class, and a function that only accepts strings:
 
 ```r
 setClass("Point", representation(x = "numeric"))
@@ -21,15 +21,15 @@ want_chr(pt@x)
 ```
 
 That is accepted. `pt@x` is declared `"numeric"` in the class definition, it is being passed where a
-`character` is required, and no finding is reported — because the checker cannot see inside S4 at all.
-Turn on strict mode and it says so plainly:
+`character` is required, and no finding is reported, because the checker cannot see inside S4. Strict
+mode reports it as an undetermined type:
 
 ```text
 error[strict]: strict mode: this expression has an undetermined type (`Unknown`)
 ```
 
-R6 behaves the same way. This is not a gap that will close soon: both systems build their objects at
-runtime out of values the checker would have to execute to understand.
+R6 behaves the same way. This gap will not close soon: both systems build their objects at runtime
+out of values the checker would have to execute to understand.
 
 ## Declaring a type
 
@@ -41,8 +41,8 @@ ada <- list(name = "Ada", age = 36L)
 ```
 
 `@type` declares a nominal type — a name that is its own type, distinct from everything else, even
-things with an identical representation. `@new` is the one way a plain list becomes one, and it checks
-the list against the declared shape as it goes.
+things with an identical representation. `@new` is the one way a plain list becomes one, and it
+checks the list against the declared shape as it goes.
 
 From there the checker knows what `ada` is: `ada$name` is a `character`, `ada$nam` is a reported
 mistake, and passing `ada` where a `Person` is wanted works while passing any other list does not.
@@ -70,20 +70,19 @@ new_person("Ada", "36")
 error[type-mismatch]: expected `integer`, found `character`
 ```
 
-This is the pattern to use. The `@new` is **inside** the constructor, so it is the only
-door in: everything downstream receives a `Person`, and the checker enforces that statically.
+The `@new` is **inside** the constructor, so the constructor is the only way in: everything
+downstream receives a `Person`, and the checker enforces that statically.
 
-Be clear about which half does what. `@new` is an **analysis-time** check — it is not
-`setValidity()`, not an R6 `initialize()`, and it emits no runtime assertion. It cannot know that
-`age` is non-negative, and it cannot check a field whose type it could not determine. The `stop()` on
-the line above is what enforces the invariant when the code actually runs.
-
-The pairing is the point: the `stop()` guards values at run time, the `@new` guards *shape* at
-analysis time, and both sit in the one function every caller has to go through.
+The two halves do different jobs. `@new` is an **analysis-time** check — it is not `setValidity()`,
+not an R6 `initialize()`, and it emits no runtime assertion. It cannot know that `age` is
+non-negative, and it cannot check a field whose type it could not determine. The `stop()` on the
+line above is what enforces the invariant when the code runs. The `stop()` guards values at run
+time, the `@new` guards shape at analysis time, and both sit in the one function every caller goes
+through.
 
 ## Distinct types that look identical
 
-This is the trick no structural checker can do for you:
+This is what a structural checker cannot do for you:
 
 ```r
 #: @type Celsius {double}
@@ -98,17 +97,17 @@ to_fahrenheit <- function(t) t
 error[type-mismatch]: expected `Fahrenheit`, found `Celsius`
 ```
 
-Both are `double` underneath, and neither is interchangeable with the other. Two `character` ids, two
-currencies, a validated email beside an unvalidated string — anywhere your domain has values that are
-the same shape but must not be mixed, this is how you say so.
+Both are `double` underneath, and neither is interchangeable with the other. Two `character` ids,
+two currencies, a validated email beside an unvalidated string — anywhere your domain has values
+that are the same shape but must not be mixed, this is how you say so.
 
 The representation still leaks **outward**: a `Celsius` is accepted anywhere a plain `double` is
-expected, so `t / 2` and `mean(temps)` keep working. What does not happen is the reverse — a bare
-`double` never becomes a `Celsius` on its own. That asymmetry is the whole design: arithmetic stays
-convenient, while the only way *into* the type is a `@new` you wrote.
+expected, so `t / 2` and `mean(temps)` keep working. The reverse does not hold — a bare `double`
+never becomes a `Celsius` on its own. That asymmetry is deliberate: arithmetic stays convenient,
+while the only way *into* the type is a `@new` you wrote.
 
-If you want the opposite — a name that is pure shorthand and stays interchangeable with its body — that
-is [`@alias`](/type-checking/concepts#naming-your-own-types), not `@type`.
+If you want the opposite — a name that is pure shorthand and stays interchangeable with its body —
+that is [`@alias`](/type-checking/concepts#naming-your-own-types), not `@type`.
 
 ## Types with a parameter
 
@@ -116,26 +115,27 @@ is [`@alias`](/type-checking/concepts#naming-your-own-types), not `@type`.
 #: @type Box<T> {list{value: T}}
 ```
 
-A `Box<integer>` and a `Box<character>` are different types, and the element type flows out again when
-you read it.
+A `Box<integer>` and a `Box<character>` are different types, and the element type flows out again
+when you read it.
 
 ## When to use R6
 
 Nominal types describe values. They do not give you:
 
-- **Mutable state with reference semantics.** An R6 object shared between callers, mutated in place,
-  is a thing this cannot express.
+- **Mutable state with reference semantics.** An R6 object shared between callers and mutated in
+  place is a thing this cannot express.
 - **Inheritance hierarchies.** There is no subtyping between nominal types.
 - **Dispatch.** If you need `print()` and `summary()` to do the right thing per class, that is S3.
   Those go through `UseMethod`, which dispatches at run time — the checker types such calls as
   `Unknown` and cannot follow them. (S3 *operator* dispatch, `+.Date` and friends, is resolved
   statically; method dispatch is not.)
 
-The rule: use a nominal type when you have a **value with a shape and an invariant** —
-which is most of what an analysis codebase actually passes around. Reach for R6 when you genuinely have
-an **object with identity and mutable state**, and accept that its interior is opaque to the checker.
+Use a nominal type when you have a **value with a shape and an invariant**, which is most of what an
+analysis codebase passes around. Use R6 when you have an **object with identity and mutable state**,
+and accept that its interior is opaque to the checker.
 
-Plenty of R code uses R6 for things that are really just values. Those are the ones worth converting.
+Plenty of R code uses R6 for things that are really just values. Those are the ones worth
+converting.
 
 ## Next
 

--- a/docs/src/content/docs/type-checking/limitations.md
+++ b/docs/src/content/docs/type-checking/limitations.md
@@ -1,18 +1,18 @@
 ---
 title: Limitations
-description: What ry cannot check yet, stated plainly — the gaps that matter before you adopt it
+description: What ry cannot check yet — the gaps that matter before you adopt it
 ---
 
-ry is a type checker for a language that was not designed to have one. Some of R resists
-static analysis, some of it is simply not built yet, and you should know which is which before
-you decide how much to trust a clean run.
+ry is a type checker for a language that was not designed to have one. Some of R resists static
+analysis, some of it is simply not built yet, and the difference matters when you decide how much to
+trust a clean run.
 
-One rule makes the rest of this page readable: **when the checker cannot determine a type, the
-value becomes `Unknown`, and `Unknown` is compatible with everything.** That is what stops one
-unmodeled construct from cascading into a screen of errors. It is also the shape of every gap
-below — a gap means checks are *skipped*, not that wrong answers are produced.
+One rule makes the rest of this page readable: **when the checker cannot determine a type, the value
+becomes `Unknown`, and `Unknown` is compatible with everything.** That is what stops one unmodelled
+construct from cascading into a screen of errors. It is also the shape of every gap below: a gap
+means checks are *skipped*, not that wrong answers are produced.
 
-Turning on strict mode makes those skips visible:
+Strict mode makes most of those skips visible:
 
 ```toml
 # ry.toml
@@ -21,10 +21,11 @@ typing = true
 strict = true
 ```
 
-Strict mode reports every place a value became `Unknown`, and every call whose result the shipped
-declarations could not describe — `min()` on a classed value, say, where the corpus ends the overload
-set with a permissive fallback. It is the honest way to find out how much of a file is actually being
-checked, and the only way to keep a gap from looking like a pass.
+It reports every place a value became `Unknown`, and every call whose result the shipped
+declarations could not describe — `min()` on a classed value, say, where the corpus ends the
+overload set with a permissive fallback. It is how you find out how much of a file is actually being
+checked, and it keeps a gap from looking like a pass. The one thing it does not surface is the
+attached-package tolerance described [below](#non-standard-evaluation).
 
 ## Data frames
 
@@ -36,8 +37,8 @@ accepted:
 count_rows <- function(df) df$whatever
 ```
 
-`df$whatever` is `Unknown`, `Unknown` satisfies `integer`, and the annotation reports nothing —
-even though the column may not exist and would not be an integer if it did.
+`df$whatever` is `Unknown`, `Unknown` satisfies `integer`, and the annotation reports nothing — even
+though the column may not exist and would not be an integer if it did.
 
 This is the gap that most affects analysis code, because the data frame is where analysis code
 lives. Typed column vocabularies need a row-type design that does not exist yet. Until it does,
@@ -45,39 +46,38 @@ annotations on data-frame-heavy code look protective and are not, and `strict = 
 way to see it.
 
 Matrices are the same story one level down: `%*%`, `%o%` and `%x%` produce a `matrix`, and matrix
-arithmetic and comparison are checked, but **dimensions are not tracked**. A non-conformable
-product or a transposed dimension is invisible.
+arithmetic and comparison are checked, but **dimensions are not tracked**. A non-conformable product
+or a transposed dimension is invisible.
 
 ## R's object systems
 
-**S3 is largely fine; S4 and R6 are opaque.** Operator dispatch (`+.Date`, `Ops.Class`) resolves
-statically, a directly called method is just a function, and `structure(x, class = "dog")` keeps `x`'s
-type because a class attribute is data rather than a type. `UseMethod` dispatch, and everything in S4
-and R6, is `Unknown`.
+**S3 is largely covered; S4 and R6 are opaque.** Operator dispatch (`+.Date`, `Ops.Class`) resolves
+statically, a directly called method is just a function, and `structure(x, class = "dog")` keeps
+`x`'s type because a class attribute is data rather than a type. `UseMethod` dispatch, and
+everything in S4 and R6, is `Unknown`.
 
 The full table is in the reference under
 [object systems](/reference/type-system#object-systems-s3-s4-r6), which also explains why the line
-falls there. The thing that *does* work today is declaring the class yourself — see
+falls there. What does work today is declaring the class yourself — see
 [domain modeling](/type-checking/domain-modeling).
 
 ## Non-standard evaluation
 
 `dplyr`, `data.table`, `ggplot2` and `testthat` have shipped stubs, and their data-masked verbs are
-understood: bare column names inside `mutate()` or a `data.table` bracket are column references,
-not unresolved variables, and classes flow through a pipeline. A full `read.csv |> mutate |> filter`
-chain checks clean.
+understood: bare column names inside `mutate()` or a `data.table` bracket are column references, not
+unresolved variables, and classes flow through a pipeline. A full
+`read.csv |> mutate |> filter` chain checks clean.
 
-Outside those, a data-masking function ry does not know about will report its column names as
+Outside those, a data-masking function ry does not know about reports its column names as
 unresolved. The ecosystem's standard escape hatch works — a top-level
 `utils::globalVariables(c("a", "b"))` silences them for the whole package.
 
 **Attaching a package ry does not know weakens the `unresolved` check.** A `library(pkg)` whose
-exports ry cannot enumerate means any bare name *could* be one of them, so otherwise-unresolved
-bare names are tolerated rather than reported — project-wide, not just in that file. This is what
-keeps the tool usable on real code, but where it applies a clean run says less than it looks like it
-does.
+exports ry cannot enumerate means any bare name *could* be one of them, so otherwise-unresolved bare
+names are tolerated rather than reported — project-wide, not just in that file. This is what keeps
+the tool usable on real code, but where it applies a clean run says less than it appears to.
 
-Four things narrow the hole:
+Three things narrow the hole:
 
 1. **Most packages are already known.** ry ships the export lists of the packages R code attaches
    most — see [what ships](/type-checking/stubs#what-ships). Attaching any of them keeps the check
@@ -85,12 +85,13 @@ Four things narrow the hole:
 2. **A near miss of a name in scope is still reported.** `library(shiny)` cannot explain `repositry`
    sitting next to a `repository` parameter, so that stays a finding. In a package this covers your
    top-level definitions too; in a loose script it covers locals and parameters.
-3. **`library(yourpkg)` costs nothing.** A `library()` naming your own package weakens nothing, so the
-   one in `tests/testthat.R` is harmless.
-4. **You can close it yourself** with a two-line [`stubs/<pkg>.Rtypes`](/type-checking/stubs), which
-   also silences the unknown-namespace warning.
+3. **`library(yourpkg)` costs nothing.** A `library()` naming your own package weakens nothing, so
+   the one in `tests/testthat.R` is harmless.
 
-And `strict = true` makes every tolerated read visible either way.
+The way to close it is a two-line [`stubs/<pkg>.Rtypes`](/type-checking/stubs), which also silences
+the unknown-namespace warning. Strict mode does not close it: the tolerance is applied while names
+are resolved, and strict mode reports undetermined *types*, so a tolerated read produces no finding
+in either mode.
 
 A project's own `%op%` is deliberately left opaque: it may be an NSE wrapper whose right operand is
 quoted rather than evaluated (magrittr's `%>%` is the canonical case), and checking that as an
@@ -99,28 +100,28 @@ ordinary call would reject correct code.
 ## One signature per function
 
 A `#:` annotation declares exactly one signature, and there is no way to give your own function
-several. The standard-library declarations do have them — `sum` is `integer` in and `integer` out but
-`double` in and `double` out — and that is a deliberate asymmetry rather than something to be
-extended later.
+several. The standard-library declarations do have them — `sum` is `integer` in and `integer` out
+but `double` in and `double` out — and that asymmetry is deliberate rather than pending.
 
-A name with several signatures has no single most general type, so a call to it has to be resolved by
-trying candidates instead of inferred outright. That costs the guarantee that makes this checker fast
-and its answers stable. It is worth paying for a small curated corpus that has to describe a standard
-library nobody designed with types in mind, and it is not worth paying across your codebase. Where
-you would reach for an overload, a [union](/reference/type-system#union-types) parameter usually says the
-same thing — `fn(x: integer | character) -> character` — and two functions with distinct names always
-do.
+A name with several signatures has no single most general type, so a call to it has to be resolved
+by trying candidates instead of inferred outright. That costs the principal-type guarantee the
+checker's speed and stability rest on. It is an acceptable cost for a small curated corpus that has
+to describe a standard library nobody designed with types in mind, and an unacceptable one across a
+whole codebase. Where you would reach for an overload, a
+[union](/reference/type-system#union-types) parameter usually says the same thing —
+`fn(x: integer | character) -> character` — and two functions with distinct names always do.
 
 ## Scope of analysis
 
 `source()` calls are not followed. Package files under `R/` share one namespace; every other file is
-analyzed on its own. See [project discovery](/reference/configuration#project-discovery) for the rules.
+analyzed on its own. See [project discovery](/reference/configuration#project-discovery) for the
+rules.
 
 Files directly under `tests/testthat/` are an **approximation**: ry analyzes them as one shared
 environment, helpers first. Real testthat only shares `helper*.R` and `setup*.R` that way — each
 `test-*.R` runs in its own child environment. So a name one test file defines and another uses will
-resolve here and fail when you actually run the tests. The approximation is deliberate (it keeps
-helper-defined names resolving), but it is more permissive than testthat is.
+resolve here and fail when you actually run the tests. The approximation is deliberate, because it
+keeps helper-defined names resolving, but it is more permissive than testthat is.
 
 ---
 

--- a/docs/src/content/docs/type-checking/stubs.md
+++ b/docs/src/content/docs/type-checking/stubs.md
@@ -19,7 +19,7 @@ the shipped corpus:
 | **Export lists only** | the tidyverse (and `library(tidyverse)` itself), `knitr`, `rlang`, `glue`, `magrittr`, `scales`, `jsonlite`, `R6`, and every namespace R ships |
 
 The difference between the last two rows matters. A **typed** namespace gives calls through it real
-types. An **export list** gives no types, but it does tell the checker which names exist — which is what
+types. An **export list** gives no types, but it tells the checker which names exist, which is what
 keeps [`unresolved`](/reference/diagnostic-codes) working, so a typo next to a real export is still
 caught.
 
@@ -29,11 +29,12 @@ Attaching a package ry has never heard of weakens the `unresolved` check across 
 bare name *could* be one of that package's exports, so unresolved names are tolerated rather than
 reported.
 
-Two things limit the damage. A near-miss of a name your **own** project binds is still reported —
-`library(shiny)` cannot explain `repositry` sitting next to a `repository` parameter. And
-`strict = true` makes every tolerated read visible.
+One thing limits the damage: a near miss of a name your **own** project binds is still reported —
+`library(shiny)` cannot explain `repositry` sitting next to a `repository` parameter. Strict mode
+does not help here, because the tolerance is applied while names are resolved rather than through
+the type of the result.
 
-The real fix is to declare the package yourself.
+The fix is to declare the package yourself.
 
 ## Teaching it about a package
 
@@ -48,19 +49,20 @@ connect: fn(host: character) -> Session
 ```
 
 Stub declarations are bare — no `#:` prefix, and `@type` in a stub names an opaque type rather than
-giving it a representation. That is usually what you want for a package's own objects: you care that
-`connect()` returns a `Session` and that a `Session` is not a `character`, not what is inside it.
+giving it a representation. That is usually what you want for a package's own objects: what matters
+is that `connect()` returns a `Session` and that a `Session` is not a `character`, not what is
+inside it.
 
-That gives you three things at once: `connect()` gets a real signature, `mypkg::connect` validates as a
-known namespace, and the unknown-namespace warning goes away.
+That gives you three things at once: `connect()` gets a real signature, `mypkg::connect` validates
+as a known namespace, and the unknown-namespace warning goes away.
 
 You do not have to describe the whole package. Declare what you call.
 
 ## Overriding a shipped declaration
 
-The same mechanism corrects the shipped corpus. A declaration in your `stubs/` directory **replaces**
-the shipped one of the same name, so if a return type is wrong, or a name is missing for your version
-of a package, you can fix it locally without waiting for a release.
+The same mechanism corrects the shipped corpus. A declaration in your `stubs/` directory
+**replaces** the shipped one of the same name, so if a return type is wrong, or a name is missing
+for your version of a package, you can fix it locally without waiting for a release.
 
 Overriding a name does not remove it from its own namespace: `stats::sd` stays valid under an `sd`
 override.

--- a/docs/src/content/docs/type-checking/tutorial.md
+++ b/docs/src/content/docs/type-checking/tutorial.md
@@ -45,10 +45,10 @@ error[type-mismatch]: expected `double`, found `character`
 ```
 
 Found without running anything, and pointing at the argument rather than at the line that would have
-blown up.
+failed.
 
 The annotation is a promise the checker holds you to in both directions. Claim the wrong return type
-and it says so, pointing at the body:
+and it reports that too, pointing at the body:
 
 ```r
 #: fn(price: double, rate: double) -> character
@@ -86,20 +86,20 @@ error[type-mismatch]: expected `double`, found `character`
 The same error. `*` is arithmetic, so `price` and `rate` are numbers — the checker worked that out
 from the body. This is **inference**, and it is why most R needs no annotations at all.
 
-It is worth knowing what kind, because that decides how far you can trust it. ry uses
-**Hindley–Milner** inference, the algorithm behind ML, Haskell and Elm. Two properties matter here:
+Which kind of inference decides how far you can trust it. ry uses **Hindley–Milner** inference, the
+algorithm behind ML, Haskell and Elm. Two properties matter here:
 
-- It computes a **principal type** — the single most general type consistent with how a value is used.
-  Not a guess, not a heuristic. Run it twice and you get the same answer; run it on a colleague's
-  machine and they get yours. (Calls into the standard library are the one place a *choice* is made,
-  because a handful of R's builtins are declared with several signatures; the
+- It computes a **principal type** — the single most general type consistent with how a value is
+  used. Not a guess, not a heuristic. Run it twice and you get the same answer; run it on a
+  colleague's machine and they get yours. (Calls into the standard library are the one place a
+  *choice* is made, because a handful of R's builtins are declared with several signatures; the
   [rules for that](/reference/type-system#overload-sets) are fixed and deterministic too.)
 - It does not silently accept a contradiction. Within the part of your program it can model, if the
-  types cannot line up, you hear about it.
+  types cannot line up, it reports that.
 
-That second clause carries the honest limit. R has constructs no type system can follow — `UseMethod`
+The second clause carries the limit. R has constructs no type system can follow — `UseMethod`
 dispatch, data-frame columns, S4. There the checker yields `Unknown` rather than guessing, and
-`Unknown` is compatible with everything, so one gap does not flood your screen with consequences.
+`Unknown` is compatible with everything, so one gap produces no consequential errors.
 [Strict mode](#7-strict-mode) is how you find those gaps.
 
 ## 3. When to annotate
@@ -107,9 +107,10 @@ dispatch, data-frame columns, S4. There the checker yields `Unknown` rather than
 Inference handles the interior. Annotate at the edges:
 
 - **Exported functions**, and anything else another file or another person calls. The annotation is
-  documentation the checker enforces, and it stops a change to the body quietly changing the contract.
-- **Where you want a promise held.** If a function must return a `double`, say so, and the day someone
-  makes it return a list you find out immediately.
+  documentation the checker enforces, and it stops a change to the body quietly changing the
+  contract.
+- **Where you want a promise held.** If a function must return a `double`, say so, and the day
+  someone makes it return a list you find out immediately.
 - **Where inference cannot see.** A value that arrives from a data frame, a database, or `readRDS()`
   is `Unknown`. If you know what it is, say so.
 
@@ -133,8 +134,8 @@ error[type-mismatch]: expected a list, found `list{retries: integer} | NULL`
       ^^^^^^^^^^^^^^
 ```
 
-The `|` makes a union: `config` is *either* that list *or* `NULL`. You cannot reach into it until you
-have ruled out `NULL`. Add the guard and the error goes away:
+The `|` makes a union: `config` is *either* that list *or* `NULL`. You cannot reach into it until
+you have ruled out `NULL`. Add the guard and the error goes away:
 
 ```r
 #: fn(config: list{retries: integer} | NULL) -> integer
@@ -148,8 +149,8 @@ retry_count <- function(config) {
 1 file checked, no problems
 ```
 
-The checker follows the `if`: after the early return, `config` cannot be `NULL` any more, so the field
-access is fine. That is called narrowing.
+The checker follows the `if`: after the early return, `config` cannot be `NULL` any more, so the
+field access is fine. That is called narrowing.
 
 ## 5. Domain types
 
@@ -168,9 +169,9 @@ to_fahrenheit <- function(t) t
 error[type-mismatch]: expected `Fahrenheit`, found `Celsius`
 ```
 
-`@type` makes a name that is its own type, distinct from everything else even when the representation
-is identical. This is the part no amount of inference can do for you — only you know that these two
-numbers mean different things.
+`@type` makes a name that is its own type, distinct from everything else even when the
+representation is identical. This is the part inference cannot do for you: only you know that these
+two numbers mean different things.
 
 See [domain modeling](/type-checking/domain-modeling) for constructors and validation.
 
@@ -183,8 +184,8 @@ identity2 <- function(x) x
 ```
 
 Hover it and you get `<T> fn(x: T) -> T` — for any type `T`, takes one and returns the same one. Add
-arithmetic and the promise narrows on its own to `<T: numeric> fn(x: T) -> T`. You asked for neither,
-and there is nothing to maintain.
+arithmetic and the type narrows on its own to `<T: numeric> fn(x: T) -> T`. Neither has to be asked
+for, and neither has to be maintained.
 
 One caveat: a single `T` used twice means *the same* type twice. Against
 `<T: numeric> fn(value: T, factor: T) -> T`, the call `scale_by(2L, 0.5)` is reported, because
@@ -192,8 +193,8 @@ One caveat: a single `T` used twice means *the same* type twice. Against
 
 ## 7. Strict mode
 
-A clean run means "I found no contradictions". It does not mean "I checked everything". Strict mode
-reports every place a value became `Unknown`:
+A clean run means the checker found no contradictions. It does not mean it checked everything.
+Strict mode reports every place a value became `Unknown`:
 
 ```toml
 # ry.toml
@@ -215,9 +216,9 @@ error[strict]: strict mode: this expression has an undetermined type (`Unknown`)
       ^^^^^^^^^^^^
 ```
 
-Data-frame columns have no types yet, so that expression was never really checked — and without strict
-mode it looked like a pass. Turn this on for the modules you rely on, not across a legacy codebase on
-day one.
+Data-frame columns have no types yet, so that expression was never really checked, and without
+strict mode it looked like a pass. Turn this on for the modules you rely on, not across a legacy
+codebase on day one.
 
 ## 8. Adopting it a file at a time
 
@@ -230,8 +231,8 @@ setting, in either direction:
 # typing: strict   # hold this module to the stronger standard
 ```
 
-[Adopting an existing codebase](/guides/adopting) has the order that works on a project with findings
-already in it.
+[Adopting an existing codebase](/guides/adopting) has the order that works on a project with
+findings already in it.
 
 ## Where to go next
 

--- a/docs/src/content/docs/why-ry.md
+++ b/docs/src/content/docs/why-ry.md
@@ -9,11 +9,11 @@ None of them shares what it learned with the others, so each one starts over.
 
 ## Static, not a live session
 
-R's language servers do know what your values are — they ask a live R session. That is why completion
-on a fitted model works so well in RStudio.
+R's language servers know what your values are because they ask a live R session. That is what makes
+completion on a fitted model work in RStudio.
 
-That is also its limit: a session knows only code that has already run, in the state it happens to be in.
-It cannot tell you about the branch you have not taken, the function nobody called, or the file you
+It is also the limit: a session knows only code that has already run, in the state it happens to be
+in. It cannot describe the branch you have not taken, the function nobody called, or the file you
 just opened. ry answers from the source alone, so the answers exist in a pull request, in CI, and
 in a file you have never run:
 
@@ -22,13 +22,13 @@ in a file you have never run:
 - a value that is sometimes `NULL`, used as though it never is
 - a name you deleted in another file
 
-And everything is served from **one** understanding: formatting, analysis, editor features and type
+All of these come from **one** understanding: formatting, analysis, editor features and type
 checking are views onto the same knowledge.
 
 ## Speed on large codebases
 
-Large R projects are where tooling latency stops being a detail: once a check takes long enough to
-break your train of thought, you stop running it, and the tool may as well not exist.
+Latency matters most on large R projects, where a check slow enough to interrupt your work stops
+being run at all.
 
 ry is written in Rust, and analysis is incremental: an edit re-checks only what that edit could
 have affected, not the project. It is tested against roughly 970,000 lines of real R — 69 CRAN
@@ -36,8 +36,8 @@ packages plus R's own base library — and the check that an edit does not trigg
 should runs on every change.
 
 `check` and `fmt` never load R and never execute your code, which is what makes them safe in CI and
-instant in an editor. The one exception is the [R console](/guides/r-console), which by definition
-runs R.
+fast in an editor. The one exception is the [R console](/guides/r-console), which runs R by
+definition.
 
 ## Types in dynamic languages
 
@@ -48,36 +48,42 @@ program stops scaling long before the codebase does.
 R code is full of implicit type expectations, and nothing checks them until the code runs.
 
 ry's approach rests on **inference**: the checker works out types from how values are used,
-instead of making you declare them.
+instead of requiring you to declare them.
 
 ```r
 scale <- function(x, factor) x * factor
 ```
 
 `*` is arithmetic, so both parameters are numbers. Nothing was declared, and `scale("a", 2)` is
-already an error. That is why most R needs no annotations at all — and the ones you do write live in
-`#:` comments, so the file stays ordinary R that every other tool reads. Type checking is opt-in, so
-you can adopt it one file at a time.
+already an error. This is why most R needs no annotations at all. The ones you do write live in
+`#:` comments, so the file stays ordinary R that every other tool reads, and type checking is
+opt-in, so you can adopt it one file at a time.
+
+The inference is Hindley–Milner, which is sound and close to linear on real code. That choice
+excludes two features R programmers might expect — class hierarchies and overloading in your own
+functions — because a type system that admits them can spend an unbounded amount of time on a
+single expression, which an editor cannot afford. R is dynamic enough that some constructs cannot be
+described statically at all; those become `Unknown`, which is compatible with everything, so a gap
+means a check was skipped rather than a wrong answer produced.
 
 ## Project status
 
-ry is version `0.3.0-alpha`. It is not on CRAN, and it has one maintainer. What that means in
-practice:
+ry is version `0.3.0-alpha`. It is not on CRAN, and it has one maintainer. In practice:
 
-**Stable enough to build on.** The diagnostics, the `ry.toml` keys, the diagnostic codes, and the
-JSON output are covered by tests that fail when they change. CI built on them will not break silently.
+**The interfaces are stable.** The diagnostics, the `ry.toml` keys, the diagnostic codes, and the
+JSON output are covered by tests that fail when they change, so CI built on them will not break
+silently.
 
-**Still gaining capability.** The type system is where the movement is. A new release may report
-findings an older one did not — which is the point, but it means pinning a version is sensible if you
-gate a build on a clean run.
+**The type system is still gaining capability.** A new release may report findings an older one did
+not, so pin a version if you gate a build on a clean run.
 
 **Where it runs.** `ry check` reads `.R` files and the R chunks of `.Rmd`, `.qmd`, and `.Rnw`
-documents. The editor integration does not cover literate documents yet — you get them in `check` and
-in CI, but not as you type. The formatter deliberately leaves them alone, since most of an `.Rmd` is
-prose the formatter should not rewrite.
+documents. The editor integration does not cover literate documents yet — you get them in `check`
+and in CI, but not as you type. The formatter skips them, since most of an `.Rmd` is prose the
+formatter should not rewrite.
 
-**What it will not do yet.** The gaps that matter most are data frames, S4, and R6 — see
-[limitations](/type-checking/limitations) for the full picture before you decide how far to trust a
+**What it does not cover yet.** The largest gaps are data frames, S4, and R6 — see
+[limitations](/type-checking/limitations) for the full account before deciding how far to trust a
 clean run.
 
 ## Next


### PR DESCRIPTION
Rewrites the documentation site in plain declarative sentences, using the README's "Why ry" and "Type system" sections as the style reference.

## Register

Removed punchy fragments and sales lines ("no options to argue about", "One more thing", "turning it on without drowning", "the tool may as well not exist"), rhetorical build-up ("Read that error carefully, because it is the whole idea"), and the promotion of incidental facts into selling points. Limits are stated as facts rather than as candour about limits — "the honest way to find out" is just "how you find out".

Design decisions are motivated technically rather than by their virtue. The type-system rationale now reads: R is highly dynamic, ry targets soundness and speed on large codebases, so inference is Hindley–Milner; class hierarchies and user-side overloading are excluded because a system admitting them can spend unbounded time on a single expression, which an editor cannot afford; constructs that cannot be described statically become `Unknown`, so a gap is a skipped check rather than a wrong answer.

## Structure and links

Page structure, headings and links are unchanged, except for two headings that editorialised rather than naming their subject (`One more thing` → `The type checker`; `You can give your own classes a checked type today` → `Declaring a checked type for your own classes`). No link targeted either. All 337 anchors across 27 pages still resolve, and `astro build` succeeds.

`reference/formatting-rules.md` is generated, so the edits went into `crates/format/tests/formatter.template.md` and the page was regenerated; `cargo test -p format --test test_format_docs` passes without `RY_BLESS`.

## Verification

Every claim about tool behaviour was re-checked by running the `ry` binary on throwaway projects — diagnostics, exit codes, config discovery and failure, suppression comments, stub loading, literate documents, the `library()` tolerance rules, and the R-console startup errors. Hover and completion were checked by driving `ry server` over LSP stdio.

That turned up five stale claims, all corrected:

| Page | Was | Is |
| --- | --- | --- |
| `type-checking/concepts` | `@type and @alias declarations need their own #: block` | The real message, with its backticks and its second clause |
| `reference/configuration` | A misplaced top-level key reports "unknown config key" | It names the table the key belongs under |
| `guides/continuous-integration` | `--min-severity error` — "warnings still print but no longer fail anything" | Warnings are neither printed nor counted |
| `features` | `make: fn(x: T) -> list{T, integer}` | `make: <T> fn(x: T) -> list{T, integer}` |
| `type-checking/limitations`, `type-checking/stubs` | "`strict = true` makes every tolerated read visible" | It does not — see below |

### The strict-mode gap

With a `library(<package with no manifest>)` in the project, a read of a name nothing defines produces **no finding at all** under `typing = true, strict = true` — verified across four shapes (bare read, call, call assigned then used, value used numerically). The tolerance is applied while names are resolved, and strict mode reports undetermined *types* at their origin, so a tolerated read falls between the two layers.

Rather than paper over it, the docs now say strict does not close that hole and that declaring the package is what does. The gap is filed in `.agents/memory/backlog.md` with the repro and a suggested direction.

Strict mode's other claims all hold and were confirmed: `Unknown` origins from unsupported constructs and from `Any`-returning stub calls (`min()` on a classed value, `data.frame()`, `subset()`, `df$amount`), and escalation of genuinely-unresolved names from warning to error.

## Memory

`MEMORY.md` gains the register rule as a durable documentation standard, and the "verify against the binary" entry now records that a prose-only pass still found five false claims, along with the four kinds that drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgYrv36BxnXb3GcP7hgNzt)_